### PR TITLE
fix: Update check for give author as both WordImpress and GiveWP

### DIFF
--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -179,7 +179,7 @@ function give_filter_addons_do_filter_addons( $plugin_menu ) {
 
 	foreach ( $plugins['all'] as $plugin_slug => $plugin_data ) {
 
-		if ( false !== strpos( $plugin_data['Name'], 'Give' ) && false !== strpos( $plugin_data['AuthorName'], 'WordImpress' ) ) {
+		if ( false !== strpos( $plugin_data['Name'], 'Give' ) && ( false !== strpos( $plugin_data['AuthorName'], 'WordImpress' ) || false !== strpos( $plugin_data['AuthorName'], 'GiveWP' ) ) ) {
 			$plugins['give'][ $plugin_slug ]           = $plugins['all'][ $plugin_slug ];
 			$plugins['give'][ $plugin_slug ]['plugin'] = $plugin_slug;
 			// replicate the next step.


### PR DESCRIPTION
Closes #3700 

## Description
This PR fixes the count in the Advanced Plugin Give page.
It will now look for authors both `WordImpress` & `GiveWP`.

## How Has This Been Tested?
Tested by adding/deleting Give addons.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.