### PR TITLE
fix: Set all Give date fields autocomplete to off

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -167,12 +167,12 @@ class Give_Payment_History_Table extends WP_List_Table {
 				<div class="give-filter give-filter-half">
 					<label for="start-date"
 					       class="give-start-date-label"><?php _e( 'Start Date', 'give' ); ?></label>
-					<input type="text" id="start-date" name="start-date" class="give_datepicker"
+					<input type="text" id="start-date" name="start-date" class="give_datepicker" autocomplete="off"
 					       value="<?php printf( esc_attr( $start_date ) ); ?>" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
 				</div>
 				<div class="give-filter give-filter-half">
 					<label for="end-date" class="give-end-date-label"><?php _e( 'End Date', 'give' ); ?></label>
-					<input type="text" id="end-date" name="end-date" class="give_datepicker"
+					<input type="text" id="end-date" name="end-date" class="give_datepicker" autocomplete="off"
 					       value="<?php printf( esc_attr( $end_date ) ); ?>" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
 				</div>
 			</div>

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -177,7 +177,7 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 											<?php $localized_date_format = give_get_localized_date_format_to_js(); ?>
 											<p>
 												<label for="give-payment-date" class="strong"><?php _e( 'Date:', 'give' ); ?></label>&nbsp;
-												<input type="text" id="give-payment-date" name="give-payment-date" value="<?php echo esc_attr( date( get_option( 'date_format' ), $payment_date ) ); ?>" class="medium-text give_datepicker" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
+												<input type="text" id="give-payment-date" name="give-payment-date" value="<?php echo esc_attr( date( get_option( 'date_format' ), $payment_date ) ); ?>" autocomplete="off" class="medium-text give_datepicker" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
 											</p>
 										</div>
 

--- a/includes/admin/tools/export/class-give-export-donations.php
+++ b/includes/admin/tools/export/class-give-export-donations.php
@@ -232,16 +232,18 @@ if ( ! class_exists( 'Give_Export_Donations' ) ) {
 							<div class="give-clearfix">
 								<?php
 								$args = array(
-									'id'          => 'give-payment-export-start',
-									'name'        => 'start',
-									'placeholder' => __( 'Start date', 'give' ),
+									'id'           => 'give-payment-export-start',
+									'name'         => 'start',
+									'placeholder'  => __( 'Start date', 'give' ),
+									'autocomplete' => 'off',
 								);
 								echo Give()->html->date_field( $args ); ?>
 								<?php
 								$args = array(
-									'id'          => 'give-payment-export-end',
-									'name'        => 'end',
-									'placeholder' => __( 'End date', 'give' ),
+									'id'           => 'give-payment-export-end',
+									'name'         => 'end',
+									'placeholder'  => __( 'End date', 'give' ),
+									'autocomplete' => 'off'
 								);
 								echo Give()->html->date_field( $args ); ?>
 							</div>

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -108,16 +108,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<?php
 								// Start Date form field for donors
 								echo Give()->html->date_field( array(
-									'id'          => 'give_donor_export_start_date',
-									'name'        => 'donor_export_start_date',
-									'placeholder' => esc_attr__( 'Start date', 'give' ),
+									'id'           => 'give_donor_export_start_date',
+									'name'         => 'donor_export_start_date',
+									'placeholder'  => esc_attr__( 'Start date', 'give' ),
+									'autocomplete' => 'off',
 								) );
 
 								// End Date form field for donors
 								echo Give()->html->date_field( array(
-									'id'          => 'give_donor_export_end_date',
-									'name'        => 'donor_export_end_date',
-									'placeholder' => esc_attr__( 'End date', 'give' ),
+									'id'           => 'give_donor_export_end_date',
+									'name'         => 'donor_export_end_date',
+									'placeholder'  => esc_attr__( 'End date', 'give' ),
+									'autocomplete' => 'off',
 								) );
 
 								// Donation forms dropdown for donors export


### PR DESCRIPTION
Closes #3675 

## Description
This PR sets `autocomplete="off"` to all the datepicker fields in Give.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.