### PR TITLE
feat: include custom columns in donor export CSV #3709

### DIFF
--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -159,7 +159,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 	 */
 	public function csv_cols() {
 
-		$columns = $this->get_default_columns();
+		$columns = give_export_donors_get_default_columns();
 		$cols    = $this->get_cols( $columns );
 
 		return $cols;

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -133,6 +133,33 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 	}
 
 	/**
+	 * This function is used to define default columns for export.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @return array
+	 */
+	public function get_default_columns() {
+
+		$default_columns = array(
+			'full_name'          => __( 'Name', 'give' ),
+			'email'              => __( 'Email', 'give' ),
+			'address'            => __( 'Address', 'give' ),
+			'userid'             => __( 'User ID', 'give' ),
+			'donor_created_date' => __( 'Donor Created Date', 'give' ),
+			'donations'          => __( 'Number of donations', 'give' ),
+			'donation_sum'       => __( 'Total Donated', 'give' ),
+		);
+
+		/**
+		 * This filter will be used to define default columns for export.
+		 *
+		 * @since 2.2.6
+		 */
+		return apply_filters( 'give_export_donors_get_default_columns', $default_columns );
+	}
+
+	/**
 	 * Cache donor ids.
 	 *
 	 * @since  1.8.9

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -242,9 +242,9 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 
 		if ( ! empty( $this->form ) ) {
 
-			// Export donors for a specific donation form and also within specified timeframe
+			// Export donors for a specific donation form and also within specified timeframe.
 			$args = array(
-				'output'     => 'payments', // Use 'posts' to get standard post objects
+				'output'     => 'payments',
 				'post_type'  => array( 'give_payment' ),
 				'number'     => 30,
 				'paged'      => $this->step,
@@ -253,7 +253,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 				'meta_value' => absint( $this->form ),
 			);
 
-			// Check for date option filter
+			// Check for date option filter.
 			if ( ! empty( $this->data['donor_export_start_date'] ) || ! empty( $this->data['donor_export_end_date'] ) ) {
 				$args['start_date'] = ! empty( $this->data['donor_export_start_date'] ) ? date( 'Y-n-d 00:00:00', strtotime( $this->data['donor_export_start_date'] ) ) : date( 'Y-n-d 23:59:59', '1970-1-01 00:00:00' );
 				$args['end_date']   = ! empty( $this->data['donor_export_end_date'] ) ? date( 'Y-n-d 23:59:59', strtotime( $this->data['donor_export_end_date'] ) ) : date( 'Y-n-d 23:59:59', current_time( 'timestamp' ) );
@@ -312,7 +312,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 					// Cache donor ids only if admin export donor for specific form.
 					$this->cache_donor_ids();
 				}
-			}
+			} // End if().
 		} else {
 
 			// Export all donors.
@@ -323,7 +323,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 				'offset' => $offset,
 			);
 
-			// Check for date option filter
+			// Check for date option filter.
 			if ( ! empty( $this->data['donor_export_start_date'] ) || ! empty( $this->data['donor_export_end_date'] ) ) {
 				$args['date'] = array(
 					'start' => ! empty( $this->data['donor_export_start_date'] ) ? date( 'Y-n-d 00:00:00', strtotime( $this->data['donor_export_start_date'] ) ) : date( 'Y-n-d 23:59:59', '1970-1-01 00:00:00' ),
@@ -399,7 +399,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 			$address = give_get_donor_address( $donor->user_id );
 		}
 
-		// Set columns
+		// Set columns.
 		if ( ! empty( $columns['full_name'] ) ) {
 			$donor_name              = give_get_donor_name_by( $donor->id, 'donor' );
 			$data[ $i ]['full_name'] = $donor_name;

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -133,33 +133,6 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 	}
 
 	/**
-	 * This function is used to define default columns for export.
-	 *
-	 * @since 2.2.6
-	 *
-	 * @return array
-	 */
-	public function get_default_columns() {
-
-		$default_columns = array(
-			'full_name'          => __( 'Name', 'give' ),
-			'email'              => __( 'Email', 'give' ),
-			'address'            => __( 'Address', 'give' ),
-			'userid'             => __( 'User ID', 'give' ),
-			'donor_created_date' => __( 'Donor Created Date', 'give' ),
-			'donations'          => __( 'Number of donations', 'give' ),
-			'donation_sum'       => __( 'Total Donated', 'give' ),
-		);
-
-		/**
-		 * This filter will be used to define default columns for export.
-		 *
-		 * @since 2.2.6
-		 */
-		return apply_filters( 'give_export_donors_get_default_columns', $default_columns );
-	}
-
-	/**
 	 * Cache donor ids.
 	 *
 	 * @since  1.8.9

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -395,8 +395,8 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 
 		// Set address variable.
 		$address = '';
-		if ( isset( $donor->user_id ) && $donor->user_id > 0 ) {
-			$address = give_get_donor_address( $donor->user_id );
+		if ( isset( $donor->id ) && $donor->id > 0 ) {
+			$address = give_get_donor_address( $donor->id );
 		}
 
 		// Set columns.

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -186,14 +186,8 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 	 */
 	public function csv_cols() {
 
-		$columns = isset( $this->data['give_export_option'] ) ? $this->data['give_export_option'] : array();
-
-		// We need columns.
-		if ( empty( $columns ) ) {
-			return false;
-		}
-
-		$cols = $this->get_cols( $columns );
+		$columns = $this->get_default_columns();
+		$cols    = $this->get_cols( $columns );
 
 		return $cols;
 	}

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -206,12 +206,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 		foreach ( $columns as $key => $value ) {
 
 			switch ( $key ) {
-				case 'full_name' :
-					$cols['full_name'] = esc_html__( 'Full Name', 'give' );
-					break;
-				case 'email' :
-					$cols['email'] = esc_html__( 'Email Address', 'give' );
-					break;
+
 				case 'address' :
 					$cols['address_line1']   = esc_html__( 'Address', 'give' );
 					$cols['address_line2']   = esc_html__( 'Address 2', 'give' );
@@ -220,17 +215,9 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 					$cols['address_zip']     = esc_html__( 'Zip', 'give' );
 					$cols['address_country'] = esc_html__( 'Country', 'give' );
 					break;
-				case 'userid' :
-					$cols['userid'] = esc_html__( 'User ID', 'give' );
-					break;
-				case 'donor_created_date' :
-					$cols['donor_created_date'] = esc_html__( 'Donor Created Date', 'give' );
-					break;
-				case 'donations' :
-					$cols['donations'] = esc_html__( 'Number of Donations', 'give' );
-					break;
-				case 'donation_sum' :
-					$cols['donation_sum'] = esc_html__( 'Sum of Donations', 'give' );
+
+				default:
+					$cols[ $key ] = $value;
 					break;
 			}
 		}

--- a/includes/admin/tools/export/export-functions.php
+++ b/includes/admin/tools/export/export-functions.php
@@ -98,7 +98,7 @@ function give_do_ajax_export() {
 		);
 
 	} else {
-		
+
 		$args = array_merge( $_REQUEST, array(
 			'step'        => $step,
 			'class'       => $class,
@@ -119,3 +119,31 @@ function give_do_ajax_export() {
 }
 
 add_action( 'wp_ajax_give_do_ajax_export', 'give_do_ajax_export' );
+
+
+/**
+ * This function is used to define default columns for export.
+ *
+ * @since 2.2.6
+ *
+ * @return array
+ */
+public function give_export_donors_get_default_columns() {
+
+	$default_columns = array(
+		'full_name'          => __( 'Name', 'give' ),
+		'email'              => __( 'Email', 'give' ),
+		'address'            => __( 'Address', 'give' ),
+		'userid'             => __( 'User ID', 'give' ),
+		'donor_created_date' => __( 'Donor Created Date', 'give' ),
+		'donations'          => __( 'Number of donations', 'give' ),
+		'donation_sum'       => __( 'Total Donated', 'give' ),
+	);
+
+	/**
+	 * This filter will be used to define default columns for export.
+	 *
+	 * @since 2.2.6
+	 */
+	return apply_filters( 'give_export_donors_get_default_columns', $default_columns );
+}

--- a/includes/admin/tools/export/export-functions.php
+++ b/includes/admin/tools/export/export-functions.php
@@ -128,7 +128,7 @@ add_action( 'wp_ajax_give_do_ajax_export', 'give_do_ajax_export' );
  *
  * @return array
  */
-public function give_export_donors_get_default_columns() {
+function give_export_donors_get_default_columns() {
 
 	$default_columns = array(
 		'full_name'          => __( 'Name', 'give' ),

--- a/includes/admin/tools/export/export-functions.php
+++ b/includes/admin/tools/export/export-functions.php
@@ -124,6 +124,9 @@ add_action( 'wp_ajax_give_do_ajax_export', 'give_do_ajax_export' );
 /**
  * This function is used to define default columns for export.
  *
+ * Note: This function is for internal purposes only.
+ * Use filter "give_export_donors_get_default_columns" instead.
+ *
  * @since 2.2.6
  *
  * @return array

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -128,16 +128,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<p><?php esc_html_e( 'Export Columns:', 'give' ); ?></p>
 									<ul id="give-export-option-ul">
 										<?php
-										if ( ! class_exists( 'Give_Batch_Export' ) ) {
-											require_once GIVE_PLUGIN_DIR . 'includes/admin/tools/export/class-batch-export.php';
-										}
-
-										if ( ! class_exists( 'Give_Batch_Donors_Export' ) ) {
-											require_once GIVE_PLUGIN_DIR . 'includes/admin/tools/export/class-batch-export-donors.php';
-										}
-
-										$batch_donors_export  = new Give_Batch_Donors_Export();
-										$donor_export_columns = $batch_donors_export->get_default_columns();
+										$donor_export_columns = give_export_donors_get_default_columns();
 
 										foreach ( $donor_export_columns as $column_name => $column_label ) {
 											?>

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -55,7 +55,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							</a>
 						</td>
 					</tr>
-					
+
 					<tr class="give-export-pdf-sales-earnings">
 						<td scope="row" class="row-title">
 							<h3>
@@ -130,59 +130,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<input type="submit" value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>"
 								       class="button-secondary"/>
 
-								<div id="export-donor-options-wrap"
-								     class="give-clearfix">
-									<p><?php _e( 'Export Columns:', 'give' ); ?></p>
+								<div id="export-donor-options-wrap" class="give-clearfix">
+									<p><?php esc_html_e( 'Export Columns:', 'give' ); ?></p>
 									<ul id="give-export-option-ul">
-										<li>
-											<label for="give-export-fullname">
-												<input type="checkbox" checked
-												       name="give_export_option[full_name]"
-												       id="give-export-fullname"><?php _e( 'Name', 'give' ); ?>
-											</label>
-										</li>
-										<li>
-											<label for="give-export-email">
-												<input type="checkbox" checked
-												       name="give_export_option[email]"
-												       id="give-export-email"><?php _e( 'Email', 'give' ); ?>
-											</label>
-										</li>
-										<li>
-											<label for="give-export-address">
-												<input type="checkbox" checked
-												       name="give_export_option[address]"
-												       id="give-export-address"><?php _e( 'Address', 'give' ); ?>
-											</label>
-										</li>
-										<li>
-											<label for="give-export-userid">
-												<input type="checkbox" checked
-												       name="give_export_option[userid]"
-												       id="give-export-userid"><?php _e( 'User ID', 'give' ); ?>
-											</label>
-										</li>
-										<li>
-											<label for="give-export-first-donation-date">
-												<input type="checkbox" checked
-												       name="give_export_option[donor_created_date]"
-												       id="give-export-first-donation-date"><?php _e( 'Donor Created Date', 'give' ); ?>
-											</label>
-										</li>
-										<li>
-											<label for="give-export-donation-number">
-												<input type="checkbox" checked
-												       name="give_export_option[donations]"
-												       id="give-export-donation-number"><?php _e( 'Number of Donations', 'give' ); ?>
-											</label>
-										</li>
-										<li>
-											<label for="give-export-donation-sum">
-												<input type="checkbox" checked
-												       name="give_export_option[donation_sum]"
-												       id="give-export-donation-sum"><?php _e( 'Total Donated', 'give' ); ?>
-											</label>
-										</li>
+										<?php
+										if ( ! class_exists( 'Give_Batch_Export' ) ) {
+											require_once GIVE_PLUGIN_DIR . 'includes/admin/tools/export/class-batch-export.php';
+										}
+
+										if ( ! class_exists( 'Give_Batch_Donors_Export' ) ) {
+											require_once GIVE_PLUGIN_DIR . 'includes/admin/tools/export/class-batch-export-donors.php';
+										}
+
+										$batch_donors_export  = new Give_Batch_Donors_Export();
+										$donor_export_columns = $batch_donors_export->get_default_columns();
+
+										foreach ( $donor_export_columns as $column_name => $column_label ) {
+											?>
+											<li>
+												<label for="give-export-<?php echo esc_attr( $column_name ); ?>">
+													<input
+															type="checkbox"
+															checked
+															name="give_export_option[<?php echo esc_attr( $column_name ); ?>]"
+															id="give-export-<?php echo esc_attr( $column_name ); ?>"
+													/>
+													<?php echo esc_attr( $column_label ); ?>
+												</label>
+											</li>
+											<?php
+										}
+										?>
 									</ul>
 								</div>
 								<?php wp_nonce_field( 'give_ajax_export', 'give_ajax_export' ); ?>

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -24,8 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<table class="widefat export-options-table give-table striped">
 					<thead>
 					<tr>
-						<th scope="col"><?php _e( 'Export Type', 'give' ); ?></th>
-						<th scope="col"><?php _e( 'Export Options', 'give' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Export Type', 'give' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Export Options', 'give' ); ?></th>
 					</tr>
 					</thead>
 					<tbody>
@@ -44,14 +44,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<tr class="give-export-donations-history">
 						<td scope="row" class="row-title">
 							<h3>
-								<span><?php _e( 'Export Donation History', 'give' ); ?></span>
+								<span><?php esc_html_e( 'Export Donation History', 'give' ); ?></span>
 							</h3>
-							<p><?php _e( 'Download a CSV of all donations recorded.', 'give' ); ?></p>
+							<p><?php esc_html_e( 'Download a CSV of all donations recorded.', 'give' ); ?></p>
 						</td>
 						<td>
-							<a class="button"
-							   href="<?php echo add_query_arg( array( 'type' => 'export_donations' ) ); ?>">
-								<?php _e( 'Generate CSV', 'give' ); ?>
+							<a class="button" href="<?php echo add_query_arg( array( 'type' => 'export_donations' ) ); ?>">
+								<?php esc_html_e( 'Generate CSV', 'give' ); ?>
 							</a>
 						</td>
 					</tr>
@@ -59,23 +58,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<tr class="give-export-pdf-sales-earnings">
 						<td scope="row" class="row-title">
 							<h3>
-								<span><?php _e( 'Export PDF of Donations and Income', 'give' ); ?></span>
+								<span><?php esc_html_e( 'Export PDF of Donations and Income', 'give' ); ?></span>
 							</h3>
-							<p><?php _e( 'Download a PDF of Donations and Income reports for all forms for the current year.', 'give' ); ?></p>
+							<p><?php esc_html_e( 'Download a PDF of Donations and Income reports for all forms for the current year.', 'give' ); ?></p>
 						</td>
 						<td>
-							<a class="button"
-							   href="<?php echo wp_nonce_url( add_query_arg( array( 'give-action' => 'generate_pdf' ) ), 'give_generate_pdf' ); ?>">
-								<?php _e( 'Generate PDF', 'give' ); ?>
+							<a class="button" href="<?php echo wp_nonce_url( add_query_arg( array( 'give-action' => 'generate_pdf' ) ), 'give_generate_pdf' ); ?>">
+								<?php esc_html_e( 'Generate PDF', 'give' ); ?>
 							</a>
 						</td>
 					</tr>
 					<tr class="give-export-sales-earnings">
 						<td scope="row" class="row-title">
 							<h3>
-								<span><?php _e( 'Export Income and Donation Stats', 'give' ); ?></span>
+								<span><?php esc_html_e( 'Export Income and Donation Stats', 'give' ); ?></span>
 							</h3>
-							<p><?php _e( 'Download a CSV of income and donations over time.', 'give' ); ?></p>
+							<p><?php esc_html_e( 'Download a CSV of income and donations over time.', 'give' ); ?></p>
 						</td>
 						<td>
 							<form method="post">
@@ -87,11 +85,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 									Give()->html->year_dropdown( 'end_year' ) . ' ' . Give()->html->month_dropdown( 'end_month' )
 								);
 								?>
-								<input type="hidden" name="give-action"
-								       value="earnings_export"/>
-								<input type="submit"
-								       value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>"
-								       class="button-secondary"/>
+								<input type="hidden" name="give-action" value="earnings_export"/>
+								<input type="submit" value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>" class="button-secondary"/>
 							</form>
 						</td>
 					</tr>
@@ -99,36 +94,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<tr class="give-export-donors">
 						<td scope="row" class="row-title">
 							<h3>
-								<span><?php _e( 'Export Donors', 'give' ); ?></span>
+								<span><?php esc_html_e( 'Export Donors', 'give' ); ?></span>
 							</h3>
-							<p><?php _e( 'Download a CSV of donors. Column values reflect totals across all donation forms by default, or a single donation form if selected.', 'give' ); ?></p>
+							<p><?php esc_html_e( 'Download a CSV of donors. Column values reflect totals across all donation forms by default, or a single donation form if selected.', 'give' ); ?></p>
 						</td>
 						<td>
 							<form method="post" id="give_donor_export" class="give-export-form">
 								<?php
-								// Start Date form field for donors
+								// Start Date form field for donors.
 								echo Give()->html->date_field( array(
 									'id'          => 'give_donor_export_start_date',
 									'name'        => 'donor_export_start_date',
 									'placeholder' => esc_attr__( 'Start date', 'give' ),
 								) );
 
-								// End Date form field for donors
+								// End Date form field for donors.
 								echo Give()->html->date_field( array(
 									'id'          => 'give_donor_export_end_date',
 									'name'        => 'donor_export_end_date',
 									'placeholder' => esc_attr__( 'End date', 'give' ),
 								) );
 
-								// Donation forms dropdown for donors export
+								// Donation forms dropdown for donors export.
 								echo Give()->html->forms_dropdown( array(
 									'name'   => 'forms',
 									'id'     => 'give_donor_export_form',
 									'chosen' => true,
 								) );
 								?>
-								<input type="submit" value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>"
-								       class="button-secondary"/>
+								<input type="submit" value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>" class="button-secondary"/>
 
 								<div id="export-donor-options-wrap" class="give-clearfix">
 									<p><?php esc_html_e( 'Export Columns:', 'give' ); ?></p>
@@ -165,8 +159,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								</div>
 								<?php wp_nonce_field( 'give_ajax_export', 'give_ajax_export' ); ?>
 								<input type="hidden" name="give-export-class" value="Give_Batch_Donors_Export"/>
-								<input type="hidden" name="give_export_option[query_id]"
-								       value="<?php echo uniqid( 'give_' ); ?>"/>
+								<input type="hidden" name="give_export_option[query_id]" value="<?php echo uniqid( 'give_' ); ?>"/>
 							</form>
 						</td>
 					</tr>
@@ -174,9 +167,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<tr class="give-export-core-settings">
 						<td scope="row" class="row-title">
 							<h3>
-								<span><?php _e( 'Export Give Settings', 'give' ); ?></span>
+								<span><?php esc_html_e( 'Export Give Settings', 'give' ); ?></span>
 							</h3>
-							<p><?php _e( 'Download an export of Give\'s settings and import it in a new WordPress installation.', 'give' ); ?></p>
+							<p><?php esc_html_e( 'Download an export of Give\'s settings and import it in a new WordPress installation.', 'give' ); ?></p>
 						</td>
 						<td>
 							<form method="post">
@@ -184,23 +177,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 								$export_excludes = apply_filters( 'settings_export_excludes', array() );
 								if ( ! empty( $export_excludes ) ) {
 									?>
-									<i class="settings-excludes-title"><?php echo __( 'Checked options from the list will not be exported.', 'give' ); ?></i>
+									<i class="settings-excludes-title"><?php esc_html_e( 'Checked options from the list will not be exported.', 'give' ); ?></i>
 									<ul class="settings-excludes-list">
 										<?php foreach ( $export_excludes as $option_key => $option_label ) { ?>
 											<li>
 												<label for="settings_export_excludes[<?php echo $option_key ?>]">
 													<input
-														type="checkbox" checked
-														name="settings_export_excludes[<?php echo $option_key ?>]"
-														id="settings_export_excludes[<?php echo $option_key ?>]"><?php echo esc_html( $option_label ); ?>
+															type="checkbox"
+															checked
+															name="settings_export_excludes[<?php echo $option_key ?>]"
+															id="settings_export_excludes[<?php echo $option_key ?>]"
+													/>
+													<?php echo esc_html( $option_label ); ?>
 												</label>
 											</li>
 										<?php } ?>
 									</ul>
 								<?php } ?>
 								<input type="hidden" name="give-action" value="core_settings_export"/>
-								<input type="submit" value="<?php esc_attr_e( 'Export JSON', 'give' ); ?>"
-								       class="button-secondary"/>
+								<input type="submit" value="<?php esc_attr_e( 'Export JSON', 'give' ); ?>" class="button-secondary"/>
 							</form>
 						</td>
 					</tr>


### PR DESCRIPTION
## Description
This PR resolves #3709 

## How Has This Been Tested?
I've tested this PR by processing a donation with new donor email and then exporting the same details with the phone number as the custom field.

**Snippet PR:** https://github.com/impress-org/give-snippet-library/pull/86

**Note:** I've noticed that exporting donor CSV is not displaying address properly. So, I've fixed that issue as well in this PR.

## Screenshots (jpeg or gifs if applicable):

**1. Added custom field on export donor screen**
![image](https://user-images.githubusercontent.com/1852711/46488274-d487a180-c81f-11e8-9e3e-eede83c3bbd4.png)

**2. Added custom field with its data stored in exported CSV**
![image](https://user-images.githubusercontent.com/1852711/46488131-765abe80-c81f-11e8-8ca9-07bc5856a2ae.png)

## Types of changes
New feature (a non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.