### PR TITLE
fix: do not display shortcode generator above form content

### DIFF
--- a/assets/src/css/admin/shortcodes.scss
+++ b/assets/src/css/admin/shortcodes.scss
@@ -81,10 +81,6 @@ button.sc-button {
 	margin-right: 5px;
 }
 
-.give-metabox-panel-wrap #form_content_options .sc-wrap {
-  display: none;
-}
-
 div.sc-menu {
 	display: none;
 	position: absolute;

--- a/assets/src/css/admin/shortcodes.scss
+++ b/assets/src/css/admin/shortcodes.scss
@@ -81,6 +81,10 @@ button.sc-button {
 	margin-right: 5px;
 }
 
+.give-metabox-panel-wrap #form_content_options .sc-wrap {
+  display: none;
+}
+
 div.sc-menu {
 	display: none;
 	position: absolute;

--- a/includes/admin/shortcodes/class-shortcode-button.php
+++ b/includes/admin/shortcodes/class-shortcode-button.php
@@ -32,7 +32,8 @@ final class Give_Shortcode_Button {
 	 * Class constructor
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'init' ), 999 );
+		add_action( 'current_screen', array( $this, 'init' ), 999 );
+		add_action( 'admin_init', array( $this, 'ajax_handler' ) );
 	}
 
 	/**
@@ -49,9 +50,16 @@ final class Give_Shortcode_Button {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_localize_scripts' ), 13 );
 			add_action( 'media_buttons', array( $this, 'shortcode_button' ) );
 		}
+	}
 
+
+	/**
+	 * Ajax handler for shortcode
+	 *
+	 * @since 2.3.0
+	 */
+	public function ajax_handler(){
 		add_action( "wp_ajax_give_shortcode", array( $this, 'shortcode_ajax' ) );
-		add_action( "wp_ajax_nopriv_give_shortcode", array( $this, 'shortcode_ajax' ) );
 	}
 
 	/**
@@ -240,19 +248,18 @@ final class Give_Shortcode_Button {
 			'post-new.php',
 			'post-edit.php',
 			'edit.php',
-			'edit.php?post_type=page',
 		) );
 
-		$setting_page     = give_get_current_setting_page();
-		$get_data         = give_clean( $_GET );
-		$form_content_tab = isset( $get_data['give_tab'] ) ? trim( $get_data['give_tab'] ) : '';
+		$exclude_post_types = array( 'give_forms' );
+
+		/* @var WP_Screen $current_screen */
+		$current_screen = get_current_screen();
 
 		// Only run in admin post/page creation and edit screens
 		if (
 			! is_admin()
 			|| ! in_array( $pagenow, $shortcode_button_pages )
-			|| ( 'give-settings' === $setting_page )
-			|| ( 'form_content_options' === $form_content_tab )
+			|| in_array( $current_screen->post_type, $exclude_post_types )
 
 			/**
 			 * Fire the filter

--- a/includes/admin/shortcodes/class-shortcode-button.php
+++ b/includes/admin/shortcodes/class-shortcode-button.php
@@ -32,16 +32,16 @@ final class Give_Shortcode_Button {
 	 * Class constructor
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'init'), 999 );
+		add_action( 'admin_init', array( $this, 'init' ), 999 );
 	}
 
 	/**
 	 * Initialize
 	 *
-	 * @since 2.1.0
+	 * @since  2.1.0
 	 * @access public
 	 */
-	public function init(){
+	public function init() {
 		if ( $this->is_add_button() ) {
 			add_filter( 'mce_external_plugins', array( $this, 'mce_external_plugins' ), 15 );
 
@@ -243,13 +243,16 @@ final class Give_Shortcode_Button {
 			'edit.php?post_type=page',
 		) );
 
-		$setting_page = give_get_current_setting_page();
+		$setting_page     = give_get_current_setting_page();
+		$get_data         = give_clean( $_GET );
+		$form_content_tab = isset( $get_data['give_tab'] ) ? trim( $get_data['give_tab'] ) : '';
 
 		// Only run in admin post/page creation and edit screens
 		if (
 			! is_admin()
 			|| ! in_array( $pagenow, $shortcode_button_pages )
 			|| ( 'give-settings' === $setting_page )
+			|| ( 'form_content_options' === $form_content_tab )
 
 			/**
 			 * Fire the filter


### PR DESCRIPTION
## Description
This PR will fix #3739 

## How Has This Been Tested?
Manually tested

## Video
https://www.useloom.com/share/e77136638d7d47d48aab0c357b35cb27

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.