### PR TITLE
fix: remove the "Quick Edit" field from give_forms CPT

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -473,3 +473,33 @@ function give_widgets_init() {
 }
 
 add_action( 'widgets_init', 'give_widgets_init', 999 );
+
+
+/**
+ * Remove "Quick Edit" for the give_forms CPT.
+ *
+ * @since 2.3.0
+ *
+ * @param array $actions
+ * @param null  $post
+ *
+ * @return array
+ */
+function give_forms_disable_quick_edit( $actions = array(), $post = null ) {
+
+	// Abort if the post type is not "give_forms".
+	if ( ! is_post_type_archive( 'give_forms' ) ) {
+		return $actions;
+	}
+
+	// Remove the Quick Edit link.
+	if ( isset( $actions['inline hide-if-no-js'] ) ) {
+		unset( $actions['inline hide-if-no-js'] );
+	}
+
+	// Return the set of links without Quick Edit.
+	return $actions;
+
+}
+
+add_filter( 'post_row_actions', 'give_forms_disable_quick_edit', 10, 2 );


### PR DESCRIPTION
## Description

Removes the "Quick Edit" link from the `give_forms` CPT. Leaves others intact throughout WP.

## How Has This Been Tested?

- Manually

## Screenshots (jpeg or gifs if applicable):

![2018-10-11_16-46-03](https://user-images.githubusercontent.com/1571635/46839901-25921b00-cd75-11e8-8fe6-5f4dcc3922c1.png)


## Types of changes
- Feature removal 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.