### PR TITLE
fix: pass donor comment content to Akismet api request when doing spam validation #3768

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -105,6 +105,15 @@ function give_akismet( $spam ) {
 	$args['referrer']             = $_SERVER['HTTP_REFERER'];
 	$args['comment_type']         = 'contact-form';
 
+	$form_id = isset( $_POST['give-form-id'] ) ? absint( $_POST['give-form-id'] ) : 0;
+
+	// Pass Donor comment if enabled.
+	if ( give_is_donor_comment_field_enabled( $form_id ) ) {
+		$give_comment = isset( $_POST['give_comment'] ) ? give_clean( $_POST['give_comment'] ) : '';
+
+		$args['comment_content'] = $give_comment;
+	}
+
 	$ignore = array( 'HTTP_COOKIE', 'HTTP_COOKIE2', 'PHP_AUTH_PW' );
 
 	foreach ( $_SERVER as $key => $value ) {

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -95,8 +95,8 @@ function give_akismet( $spam ) {
 	// Build args array.
 	$args = array();
 
-	$args['comment_author']       = isset( $_POST['give_first'] ) ? strip_tags( trim( $_POST['give_first'] ) ) : '';
-	$args['comment_author_email'] = isset( $_POST['give_email'] ) ? $_POST['give_email'] : false;
+	$args['comment_author']       = isset( $_POST['give_first'] ) ? give_clean( $_POST['give_first'] ) : '';
+	$args['comment_author_email'] = isset( $_POST['give_email'] ) ? sanitize_email( $_POST['give_email'] ) : false;
 	$args['blog']                 = get_option( 'home' );
 	$args['blog_lang']            = get_locale();
 	$args['blog_charset']         = get_option( 'blog_charset' );


### PR DESCRIPTION
## Description
This PR will fix #3768

## How Has This Been Tested?
- Manually tested

## Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Pass Donor comment if enabled to Akismet API

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.