### PR TITLE
feat: add filter for forms dropdown args

### DIFF
--- a/includes/class-give-html-elements.php
+++ b/includes/class-give-html-elements.php
@@ -128,6 +128,17 @@ class Give_HTML_Elements {
 			)
 		);
 
+		/**
+		 * Filter the forms dropdown.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param array $form_args Arguments for forms_dropdown query.
+		 *
+		 * @return array Arguments for forms_dropdown query.
+		 */
+		$form_args = apply_filters( 'give_forms_dropdown_args', $form_args );
+
 		$cache_key   = Give_Cache::get_key( 'give_forms', $form_args, false );
 
 		// Get forms from cache.


### PR DESCRIPTION
## Description
Adds a filter to modify `WP_Query` args for `Give()->html->forms_dropdown`.

## How Has This Been Tested?
Added a filter in a custom plugin to modify the `$form_args` to add a `meta_query` key. Tested in local WordPress install.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.