### PR TITLE
Added a filter to optionally disable wpautop on the e-mail message

### DIFF
--- a/includes/emails/class-give-emails.php
+++ b/includes/emails/class-give-emails.php
@@ -407,8 +407,10 @@ class Give_Emails {
 	 * @since 1.0
 	 */
 	public function text_to_html( $message ) {
+		$disable_wpautop = false;
+		$disable_wpautop = apply_filters('give_email_disable_wpautop', $disable_wpautop );
 
-		if ( 'text/html' == $this->content_type || true === $this->html ) {
+		if ( ( 'text/html' == $this->content_type || true === $this->html ) && false === $disable_wpautop ) {
 			$message = wpautop( $message );
 		}
 


### PR DESCRIPTION
## Description
- Adds a filter to disable the entire email message from being subject to the horrors of wpautop.
- A fix for #3788

## How Has This Been Tested?
- Filter has been added. Added `add_filter('give_email_disable_wpautop', '__return_true');` to a plugin, and the e-mail returns as it was input without any random p tags. 

## Types of changes
- Added a filter to the class-give-emails.php
- Bug fix (non-breaking change which fixes an issue) 
- New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.