### PR TITLE
fix: ensure `Delete All Data` actually deletes all data #3638

### DIFF
--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -113,27 +113,41 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 
 				switch ( $type ) {
 					case 'customers':
-						$sql[]           = "DELETE FROM $wpdb->donors WHERE id IN ($ids)";
-						$table_name      = $wpdb->donors;
-						$meta_table_name = $wpdb->donormeta;
-						$sql[]           = "DELETE FROM $table_name WHERE id IN ($ids)";
-						$sql[]           = "DELETE FROM $meta_table_name WHERE donor_id IN ($ids)";
+
+						// Delete all the Give related donor and its meta.
+						$sql[] = "DELETE FROM {$wpdb->donors}";
+						$sql[] = "DELETE FROM {$wpdb->donormeta}";
 						break;
 					case 'forms':
 						$sql[] = "UPDATE {$meta_table['name']} SET meta_value = 0 WHERE meta_key = '_give_form_sales' AND {$meta_table['column']['id']} IN ($ids)";
 						$sql[] = "UPDATE {$meta_table['name']} SET meta_value = 0.00 WHERE meta_key = '_give_form_earnings' AND {$meta_table['column']['id']} IN ($ids)";
 						break;
 					case 'other':
-						$sql[] = "DELETE FROM $wpdb->posts WHERE id IN ($ids)";
-						$sql[] = "DELETE FROM $wpdb->postmeta WHERE post_id IN ($ids)";
-						$sql[] = "DELETE FROM $wpdb->comments WHERE comment_post_ID IN ($ids)";
-						$sql[] = "DELETE FROM $wpdb->give_commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments)";
-						$sql[] = "DELETE FROM $wpdb->formmeta WHERE form_id IN ($ids)";
-						$sql[] = "DELETE FROM $wpdb->logmeta WHERE meta_key = '_give_log_form_id' AND meta_value IN ($ids)";
-						$sql[] = "DELETE FROM {$wpdb->prefix}give_logs WHERE log_parent IN ($ids)";
-						$sql[] = "DELETE FROM {$wpdb->prefix}give_sequential_ordering WHERE payment_id IN ($ids)";
-						$sql[] = "DELETE FROM {$wpdb->prefix}give_donationmeta WHERE donation_id IN ($ids)";
 
+						// Delete main entries of forms and donations exists in posts table.
+						$sql[] = "DELETE FROM {$wpdb->posts} WHERE id IN ($ids)";
+
+						// Delete all the meta rows of form exists in form meta table.
+						$sql[] = "DELETE FROM {$wpdb->formmeta}";
+
+						// Delete all the meta rows of donation exists in donation meta table.
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_donationmeta";
+
+						// Delete all the Give related sequential ordering entries for donations.
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_sequential_ordering WHERE payment_id IN ($ids)";
+
+						// Delete all the Give related comments and its meta.
+						$sql[] = "DELETE FROM {$wpdb->give_comments}";
+						$sql[] = "DELETE FROM {$wpdb->give_commentmeta}";
+
+						// Delete all the Give related logs and its meta.
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_logs";
+						$sql[] = "DELETE FROM {$wpdb->logmeta}";
+
+						// Delete all the Give sessions data.
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_sessions";
+
+						// Delete Give related categories and tags data from taxonomy tables.
 						$sql[] = $wpdb->prepare(
 							"
 							DELETE FROM $wpdb->terms

--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -181,7 +181,7 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 				}
 			}
 
-			if ( ! empty( $sql ) ) {
+			if ( is_array( $sql ) && count( $sql ) > 0 ) {
 				foreach ( $sql as $query ) {
 					$wpdb->query( $query );
 				}

--- a/uninstall.php
+++ b/uninstall.php
@@ -79,16 +79,16 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 	}
 
 	// Remove all database tables.
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_donors' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_donormeta' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_customers' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_customermeta' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_paymentmeta' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_formmeta' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_logs' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_logmeta' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_sequential_ordering' );
-	$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'give_sessions' );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_donors" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_donormeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_donationmeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_formmeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_logs" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_logmeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_comments" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_commentmeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_sequential_ordering" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_sessions" );
 
 	// Cleanup Cron Events.
 	wp_clear_scheduled_hook( 'give_daily_scheduled_events' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -90,6 +90,11 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_sequential_ordering" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_sessions" );
 
+	// Remove tables which are supported with backward compatibility.
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_customers" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_customermeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_paymentmeta" );
+
 	// Cleanup Cron Events.
 	wp_clear_scheduled_hook( 'give_daily_scheduled_events' );
 	wp_clear_scheduled_hook( 'give_weekly_scheduled_events' );


### PR DESCRIPTION
## Description
This PR resolves #3638 

## How Has This Been Tested?
I've tested this PR with the Acceptance Criteria mentioned in the issue and confirmed that the below-mentioned tables are emptied/deleted properly when respective actions are taken.
- wp_give_donors
- wp_give_donormeta
- wp_give_comments
- wp_give_commentmeta
- wp_give_logs
- wp_give_logmeta
- wp_give_formmeta
- wp_give_donationmeta
- wp_give_sequential_ordering
- wp_give_sessions

Also, Give related data from posts and taxonomy tables are also deleted properly and I've checked that subscription related Give tables are deleted when the recurring add-on is uninstalled/tool used. But, there is some sort of improvement required in the code.

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.