### PR TITLE
fix: ensure all comments are truncated near limit

### DIFF
--- a/assets/src/css/frontend/_components.donor.scss
+++ b/assets/src/css/frontend/_components.donor.scss
@@ -113,7 +113,7 @@ $donor-space-triple: $donor-space * 3;
 		white-space: nowrap;
 	}
 
-	&__excerpt+&__comment{
+	&__excerpt + &__comment{
 		display: none;
 	}
 

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -79,6 +79,8 @@ $atts          = $args[2]; // Shortcode attributes.
 						$excerpt = substr( $comment, 0, $max_chars );
 					}
 
+					$excerpt = trim( $excerpt, '.!,:;' );
+
 					echo sprintf(
 						'<p class="give-donor__excerpt">%s&hellip;<span> <a class="give-donor__read-more">%s</a></span></p>',
 						nl2br( esc_html( $excerpt ) ),

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -61,25 +61,35 @@ $atts          = $args[2]; // Shortcode attributes.
 			?>
 			<div class="give-donor__content">
 				<?php
-				$comment_content = nl2br( $donation['donor_comment'] );
+				$comment     = trim( $donation['donor_comment'] );
+				$total_chars = strlen( $comment );
+				$max_chars   = $atts['comment_length'];
 
-				if ( $atts['comment_length'] < strlen( $comment_content ) ) {
-					echo sprintf(
-						'<div class="give-donor__excerpt">%s&hellip;<span> <a class="give-donor__read-more">%s</a></span></div>',
-						substr( $comment_content, 0, strpos( $comment_content, ' ', $atts['comment_length'] + 1 ) ),
-						$atts['readmore_text']
-					);
+				// A truncated excerpt is displayed if the comment is too long.
+				if ( $max_chars < $total_chars ) {
+					$excerpt    = '';
+					$offset     = -( $total_chars - $max_chars );
+					$last_space = strrpos( $comment, ' ', $offset );
+
+					if ( $last_space ) {
+						// Truncate excerpt at last space before limit.
+						$excerpt = substr( $comment, 0, $last_space );
+					} else {
+						// There are no spaces, so truncate excerpt at limit.
+						$excerpt = substr( $comment, 0, $max_chars );
+					}
 
 					echo sprintf(
-						'<div class="give-donor__comment">%s</div>',
-						$comment_content
-					);
-				} else {
-					echo sprintf(
-						'<div class="give-donor__comment">%s</div>',
-						$comment_content
+						'<p class="give-donor__excerpt">%s&hellip;<span> <a class="give-donor__read-more">%s</a></span></p>',
+						nl2br( esc_html( $excerpt ) ),
+						esc_html( $atts['readmore_text'] )
 					);
 				}
+
+				echo sprintf(
+					'<p class="give-donor__comment">%s</p>',
+					nl2br( esc_html( $comment ) )
+				);
 				?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Resolves #3799.

Previously `str_pos()` was being used to truncate the excerpt, which is
problematic because the function looks forward for the next occurrence
in the haystack and may result in a `false` value if a space cannot be
found at the end of a comment.

This issue was resolved by using `strr_pos()` to look backwards from an
offset position to ensure that a comment is always truncated at the
space closest to the max character limit.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually tested:

- [x] Multiline comments.
- [x] Comments without spaces.
- [x] Comments under the character limit.
- [x] Comments that exceed the character limit.
- [x] Comments with HTML tags to ensure they are sanitized on the way in.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.