### PR TITLE
fix: add placeholder text for the page chosen dropdowns

### DIFF
--- a/includes/admin/settings/class-settings-general.php
+++ b/includes/admin/settings/class-settings-general.php
@@ -271,7 +271,8 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 								'numberposts' => 30,
 							) ),
 							'attributes' => array(
-								'data-search-type' => 'pages'
+								'data-search-type' => 'pages',
+								'data-placeholder' => esc_html__('Choose a page', 'give'),
 							)
 						),
 						array(
@@ -285,7 +286,8 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 								'numberposts' => 30,
 							) ),
 							'attributes' => array(
-								'data-search-type' => 'pages'
+								'data-search-type' => 'pages',
+								'data-placeholder' => esc_html__('Choose a page', 'give'),
 							)
 						),
 						array(
@@ -300,7 +302,8 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 								'numberposts' => 30,
 							) ),
 							'attributes' => array(
-								'data-search-type' => 'pages'
+								'data-search-type' => 'pages',
+								'data-placeholder' => esc_html__('Choose a page', 'give'),
 							)
 						),
 						array(


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Added proper placeholder text for chosen dropdowns within Settings > General for pages.

Resolves #3833 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually

## Screenshots (jpeg or gifs if applicable):

![2018-11-13_13-17-34](https://user-images.githubusercontent.com/1571635/48443597-8a5edd80-e746-11e8-9257-ea7c2b72d407.png)



## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.