### PR TITLE
fix: remove apostrophe as a thousand separator for Taiwan New Dollars

### DIFF
--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -309,7 +309,7 @@ function give_get_currencies_list() {
 			'symbol'      => '&#78;&#84;&#36;',
 			'setting'     => array(
 				'currency_position'   => 'before',
-				'thousands_separator' => '\'',
+				'thousands_separator' => ',',
 				'decimal_separator'   => '.',
 				'number_decimals'     => 2,
 			),


### PR DESCRIPTION
## Description
This PR will fix https://github.com/impress-org/give/issues/3840

## How Has This Been Tested?
Manually Tested

## Types of changes
 Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.