### PR TITLE
fix: remove usage of PHP 5.4+ shorthand bracket array declarations

### DIFF
--- a/includes/admin/tools/export/class-batch-export-forms.php
+++ b/includes/admin/tools/export/class-batch-export-forms.php
@@ -89,7 +89,7 @@ class Give_Batch_Forms_Export extends Give_Batch_Export {
 		if ( $forms->posts ) {
 			foreach ( $forms->posts as $form ) {
 
-				$row = [];
+				$row = array();
 
 				foreach ( $this->csv_cols() as $key => $value ) {
 
@@ -111,7 +111,7 @@ class Give_Batch_Forms_Export extends Give_Batch_Export {
 
 								if ( give_has_variable_prices( $form->ID ) ) {
 
-									$prices = [];
+									$prices = array();
 									foreach ( give_get_variable_prices( $form->ID ) as $price ) {
 										$prices[] = $price['name'] . ': ' . $price['amount'];
 									}


### PR DESCRIPTION
## Description
This PR will fix https://github.com/impress-org/give/issues/3847

## How Has This Been Tested?
Manually Tested

## Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.