### PR TITLE
fix: unable to process donation when email access token expires #3886

### DIFF
--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -105,8 +105,8 @@ class Give_Email_Access {
 	 */
 	public function __construct() {
 
-		// get it started
-		add_action( 'init', array( $this, 'init' ) );
+		// Get it started.
+		add_action( 'wp', array( $this, 'init' ) );
 	}
 
 	/**

--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -262,7 +262,14 @@ class Give_Email_Access {
 		}
 
 		// Set error only if email access form isn't being submitted.
-		if ( ! isset( $_POST['give_email'] ) && ! isset( $_POST['_wpnonce'] ) ) {
+		if (
+			(
+				(int) give_get_option( 'history_page' ) === get_the_ID() ||
+				(int) give_get_option( 'success_page' ) === get_the_ID()
+			) &&
+			! isset( $_POST['give_email'] ) &&
+			! isset( $_POST['_wpnonce'] )
+		) {
 			give_set_error( 'give_email_token_expired', apply_filters( 'give_email_token_expired_message', __( 'Your access token has expired. Please request a new one.', 'give' ) ) );
 		}
 

--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -106,7 +106,19 @@ class Give_Email_Access {
 	public function __construct() {
 
 		// Get it started.
-		add_action( 'wp', array( $this, 'init' ) );
+		add_action( 'wp', array( $this, 'setup' ) );
+	}
+
+	/**
+	 * Setup hooks
+	 *
+	 * @since 2.4.0
+	 */
+	public function setup(){
+		if( give_is_success_page() || give_is_history_page() ){
+			// Get it started.
+			add_action( 'wp', array( $this, 'init' ), 14 );
+		}
 	}
 
 	/**
@@ -263,10 +275,6 @@ class Give_Email_Access {
 
 		// Set error only if email access form isn't being submitted.
 		if (
-			(
-				(int) give_get_option( 'history_page' ) === get_the_ID() ||
-				(int) give_get_option( 'success_page' ) === get_the_ID()
-			) &&
 			! isset( $_POST['give_email'] ) &&
 			! isset( $_POST['_wpnonce'] )
 		) {

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -339,6 +339,17 @@ function give_get_history_page_uri() {
 }
 
 /**
+ * Determines if we're currently on the History page.
+ *
+ * @since 1.0
+ *
+ * @return bool True if on the History page, false otherwise.
+ */
+function give_is_history_page() {
+	return apply_filters( 'give_is_history_page', is_page( give_get_history_page_uri() ) );
+}
+
+/**
  * Check if a field is required
  *
  * @param string $field


### PR DESCRIPTION
## Description
This PR resolves #3886 

## How Has This Been Tested?
I've tested this PR when the access token is expired and then processed a new donation to try to reproduce the issue and it is working fine now without any errors.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.