### PR TITLE
fix: admin users to be allowed to download all the gift aid declaration forms

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -871,7 +871,8 @@ function give_can_view_receipt( $donation_id ) {
 	}
 
 	// Return to download receipts from admin panel.
-	if ( is_admin() ) {
+	if ( current_user_can( 'manage_options' ) ) {
+
 	    /**
 	     * This filter will be used to modify can view receipt response when accessed from admin.
          *

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -871,7 +871,7 @@ function give_can_view_receipt( $donation_id ) {
 	}
 
 	// Return to download receipts from admin panel.
-	if ( current_user_can( 'manage_options' ) ) {
+	if ( current_user_can( 'export_give_reports' ) ) {
 
 	    /**
 	     * This filter will be used to modify can view receipt response when accessed from admin.


### PR DESCRIPTION
## Description
This PR is related to https://github.com/impress-org/give-gift-aid/issues/131

## How Has This Been Tested?
I've tested this PR by downloading declaration forms from various locations and is working fine.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.