### PR TITLE
fix: update russian ruble currency formatting #3893

### DIFF
--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -359,8 +359,8 @@ function give_get_currencies_list() {
 			'symbol'      => '&#8381;',
 			'setting'     => array(
 				'currency_position'   => 'before',
-				'thousands_separator' => '.',
-				'decimal_separator'   => ',',
+				'thousands_separator' => ',',
+				'decimal_separator'   => '.',
 				'number_decimals'     => 2,
 			),
 		),


### PR DESCRIPTION
## Description
This PR resolves #3893

## How Has This Been Tested?
I've tested it with Stripe checkout and it passes the donation amount properly now.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.