### PR TITLE
Add a second argument to `the_title` filter to prevent fatal error

### DIFF
--- a/includes/admin/shortcodes/abstract-shortcode-generator.php
+++ b/includes/admin/shortcodes/abstract-shortcode-generator.php
@@ -298,7 +298,7 @@ abstract class Give_Shortcode_Generator {
 			foreach ( $posts as $post ) {
 				$options[ absint( $post->ID ) ] = empty( $post->post_title )
 					? sprintf( __( 'Untitled (#%s)', 'give' ), $post->ID )
-					: apply_filters( 'the_title', $post->post_title );
+					: apply_filters( 'the_title', $post->post_title, $post->ID );
 			}
 
 			$field['type']    = 'listbox';

--- a/includes/admin/shortcodes/abstract-shortcode-generator.php
+++ b/includes/admin/shortcodes/abstract-shortcode-generator.php
@@ -298,6 +298,7 @@ abstract class Give_Shortcode_Generator {
 			foreach ( $posts as $post ) {
 				$options[ absint( $post->ID ) ] = empty( $post->post_title )
 					? sprintf( __( 'Untitled (#%s)', 'give' ), $post->ID )
+					/** This filter is documented in wp-includes/post-template.php */
 					: apply_filters( 'the_title', $post->post_title, $post->ID );
 			}
 


### PR DESCRIPTION
## Description
This prevents a fatal error 

## How Has This Been Tested?
*Steps to reproduce*
1. Activate this plugin, and add a donation if one doesn't exist:
`/wp-admin/post-new.php?post_type=give_forms`
2. Activate the AMP for WordPress plugin (here's a [built branch of v1.0.0](https://github.com/ampproject/amp-wp/releases/tag/1.0.0-built))
3. In `/wp-admin` > AMP > Template Mode, select "Paired," and click "Save Changes"
4. Expected: the page reloads
5. Actual: there's a fatal error:
<img width="1425" alt="fatal-error-in-wp-admin" src="https://user-images.githubusercontent.com/4063887/49826725-3a773480-fd4d-11e8-8516-e89685e6c365.png">

With this PR, there's no error.

# Background
The fatal error is reported for [AMP_Validated_URL_Post_Type:: filter_the_title_in_post_list_table()](https://github.com/ampproject/amp-wp/blob/8f7a60ac3484ca6aa7b1ba603af33046a482ca3e/includes/validation/class-amp-validated-url-post-type.php#L1897), as that [filters the_title](https://github.com/ampproject/amp-wp/blob/8f7a60ac3484ca6aa7b1ba603af33046a482ca3e/includes/validation/class-amp-validated-url-post-type.php#L198). 

It has 2 parameters, as the [documentation](https://codex.wordpress.org/Plugin_API/Filter_Reference/the_title) for `the_title` requires. But the `apply_filters()` call here only passes it 1 argument.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

For #3895