### PR TITLE
fix: ensure new WP Twenty Nineteen theme has proper wrapping #3900

### DIFF
--- a/assets/src/css/frontend/theme-compatibility.scss
+++ b/assets/src/css/frontend/theme-compatibility.scss
@@ -29,7 +29,7 @@ body.give-twentysixteen {
 
 }
 
-//Twenty Seventeen Dark Color Scheme
+// Twenty Seventeen Dark Color Scheme
 body.give-twentyseventeen.colors-dark {
   div.give-total-wrap input.give-text-input,
   div#give_purchase_form_wrap span.give-final-total-amount,
@@ -39,6 +39,15 @@ body.give-twentyseventeen.colors-dark {
 
   form[id*="give"] fieldset {
 	background-color: transparent;
+  }
+
+}
+
+// Twenty Nineteen Compatibility.
+body.give-twentynineteen {
+
+  .give-form .give-btn:focus {
+		color: #FFF;
   }
 
 }

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -348,6 +348,9 @@ function give_add_body_classes( $class ) {
 		case 'twentyseventeen':
 			$classes[] = 'give-twentyseventeen';
 			break;
+		case 'twentynineteen':
+			$classes[] = 'give-twentynineteen';
+			break;
 
 	}
 

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -32,6 +32,9 @@ switch ( $template ) {
 	case 'twentyfifteen' :
 		echo '</div></div>';
 		break;
+	case 'twentynineteen' :
+		echo '</div></div></div>';
+		break;
 	case 'x' :
 		echo '</div></div></div></div>';
 		break;

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -34,6 +34,9 @@ switch ( $template ) {
 	case 'twentyseventeen' :
 		echo '<div class="wrap give-wrap">';
 		break;
+	case 'twentynineteen' :
+		echo '<div class="entry"><div class="entry-content"><div class="give-wrap">';
+		break;
 	case 'flatsome' :
 		echo '<div id="container" class="row product-page give-wrap"><div id="content" role="main">';
 		break;


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Added a custom wrapper for the Twenty Nineteen theme along with some very basic styles for buttons.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually

## Screenshots (jpeg or gifs if applicable):

![2018-12-12_12-52-00](https://user-images.githubusercontent.com/1571635/49898095-e3389900-fe0c-11e8-9fed-6132064cb978.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.