### PR TITLE
fix: verify the default currency formatting for all the currencies #3903

### DIFF
--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -338,9 +338,9 @@ function give_get_currencies_list() {
 			'admin_label' => sprintf( __('Turkish Lira (%1$s)', 'give'), '&#8378;'),
 			'symbol'      => '&#8378;',
 			'setting'     => array(
-				'currency_position'   => 'after',
-				'thousands_separator' => ',',
-				'decimal_separator'   => '.',
+				'currency_position'   => 'before',
+				'thousands_separator' => '.',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -681,7 +681,7 @@ function give_get_currencies_list() {
 				'currency_position'   => 'before',
 				'thousands_separator' => ',',
 				'decimal_separator'   => '.',
-				'number_decimals'     => 3,
+				'number_decimals'     => 2,
 			),
 		),
 		'KYD' => array(

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -109,8 +109,8 @@ function give_get_currencies_list() {
 			'symbol'      => '&#82;&#36;',
 			'setting'     => array(
 				'currency_position'   => 'before',
-				'thousands_separator' => ',',
-				'decimal_separator'   => '.',
+				'thousands_separator' => '.',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -299,7 +299,7 @@ function give_get_currencies_list() {
 			'symbol'      => '&#70;&#114;',
 			'setting'     => array(
 				'currency_position'   => 'before',
-				'thousands_separator' => ',',
+				'thousands_separator' => ' ',
 				'decimal_separator'   => '.',
 				'number_decimals'     => 2,
 			),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -1178,9 +1178,9 @@ function give_get_currencies_list() {
 			'admin_label' => sprintf( __('Kazakhstani tenge (%1$s)', 'give'), 'KZT'),
 			'symbol'      => 'KZT',
 			'setting'     => array(
-				'currency_position'   => 'before',
+				'currency_position'   => 'after',
 				'thousands_separator' => ' ',
-				'decimal_separator'   => '-',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -229,7 +229,7 @@ function give_get_currencies_list() {
 			'symbol'      => '&#107;&#114;.',
 			'setting'     => array(
 				'currency_position'   => 'before',
-				'thousands_separator' => '.',
+				'thousands_separator' => ' ',
 				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -139,8 +139,8 @@ function give_get_currencies_list() {
 			'symbol'      => '&nbsp;kr.&nbsp;',
 			'setting'     => array(
 				'currency_position'   => 'before',
-				'thousands_separator' => ',',
-				'decimal_separator'   => '.',
+				'thousands_separator' => '.',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -1140,7 +1140,7 @@ function give_get_currencies_list() {
 			'setting'     => array(
 				'currency_position'   => 'after',
 				'thousands_separator' => ' ',
-				'decimal_separator'   => '-',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -288,7 +288,7 @@ function give_get_currencies_list() {
 			'admin_label' => sprintf( __('Swedish Krona (%1$s)', 'give'), '&nbsp;kr.&nbsp;'),
 			'symbol'      => '&nbsp;kr.&nbsp;',
 			'setting'     => array(
-				'currency_position'   => 'before',
+				'currency_position'   => 'after',
 				'thousands_separator' => ' ',
 				'decimal_separator'   => ',',
 				'number_decimals'     => 2,

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -159,8 +159,8 @@ function give_get_currencies_list() {
 			'symbol'      => '&#70;&#116;',
 			'setting'     => array(
 				'currency_position'   => 'after',
-				'thousands_separator' => ',',
-				'decimal_separator'   => '.',
+				'thousands_separator' => ' ',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -1249,8 +1249,8 @@ function give_get_currencies_list() {
 			'symbol'      => 'MDL',
 			'setting'     => array(
 				'currency_position'   => 'after',
-				'thousands_separator' => ',',
-				'decimal_separator'   => '.',
+				'thousands_separator' => '.',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -661,7 +661,7 @@ function give_get_currencies_list() {
 				'currency_position'   => 'before',
 				'thousands_separator' => ',',
 				'decimal_separator'   => '.',
-				'number_decimals'     => 3,
+				'number_decimals'     => 2,
 			),
 		),
 		'KES' => array(

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -129,8 +129,8 @@ function give_get_currencies_list() {
 			'symbol'      => '&#75;&#269;',
 			'setting'     => array(
 				'currency_position'   => 'after',
-				'thousands_separator' => ',',
-				'decimal_separator'   => '.',
+				'thousands_separator' => ' ',
+				'decimal_separator'   => ',',
 				'number_decimals'     => 2,
 			),
 		),


### PR DESCRIPTION
## Description
This PR resolves #3903 

## How Has This Been Tested?
This PR is to verify and fix the default currency formatting for all the listed currencies against the link as mentioned on the issue. Please check Acceptance Criteria for more information.

**Note:** There are lots of currencies which are not mentioned in the link https://documentation.progress.com/output/rb/doc/index.html#page/rb/currency-formats.html. So, I kept those currencies formatting as it is.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.