### PR TITLE
fix: show donation start date instead of completed date on donor wall #3891

### DIFF
--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -49,7 +49,7 @@ $atts          = $args[2]; // Shortcode attributes.
 
 				<?php if ( true === $atts['show_time'] ) : ?>
 					<span class="give-donor__timestamp">
-						<?php echo date_i18n( give_date_format(), strtotime( $donation['_give_completed_date'] ) ); ?>
+						<?php echo esc_html( get_the_date( give_date_format(), $donation[ 'donation_id' ] ) ); ?>
 					</span>
 				<?php endif; ?>
 			</div>

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -37,13 +37,13 @@ $atts          = $args[2]; // Shortcode attributes.
 				<?php if ( true === $atts['show_name'] ) : ?>
 					<h3 class="give-donor__name">
 						<?php $donor_name = trim( $donation['_give_donor_billing_first_name'] . ' ' . $donation['_give_donor_billing_last_name'] ); ?>
-						<?php esc_html_e( $donor_name ); ?>
+						<?php echo esc_html( $donor_name ); ?>
 					</h3>
 				<?php endif; ?>
 
 				<?php if ( true === $atts['show_total'] ) : ?>
 					<span class="give-donor__total">
-						<?php echo give_donation_amount( $donation['donation_id'], true ); ?>
+						<?php echo esc_html( give_donation_amount( $donation['donation_id'], true ) ); ?>
 					</span>
 				<?php endif; ?>
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #3891 by displaying the donation start date on the donor wall instead of the donation completed date. The donation start date is actually the post date of the donation in the `wp_posts` table, so in order to retrieve it, we use `get_the_date()` and pass in the donation ID.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually tested.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Bug fix - change how the donation date is populated
- Escaping - use correct escaping functions in donor wall template

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.