### PR TITLE
fix: ensure all forms get calculated properly and not just limited to 20 with posts_per_page

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1527,7 +1527,7 @@ function give_recount_form_income_donation( $form_id = 0 ) {
 			'give_recount_form_stats_args', array(
 				'give_forms'     => $form_id,
 				'status'         => $accepted_statuses,
-				'posts_per_page' => - 1,
+				'number'         => - 1,
 				'fields'         => 'ids',
 			)
 		);
@@ -1542,12 +1542,12 @@ function give_recount_form_income_donation( $form_id = 0 ) {
 
 		if ( $payments ) {
 			foreach ( $payments as $payment ) {
-				// Ensure acceptible status only
+				// Ensure acceptable status only.
 				if ( ! in_array( $payment->post_status, $accepted_statuses ) ) {
 					continue;
 				}
 
-				// Ensure only payments for this form are counted
+				// Ensure only payments for this form are counted.
 				if ( $payment->form_id != $form_id ) {
 					continue;
 				}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Change `posts_per_page` to `number` which `Give_Payments_Query()` expects within its API. 

Resolves #2973 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually using recreated steps from issue.

## Screenshots (jpeg or gifs if applicable):

![2019-01-10_18-20-07](https://user-images.githubusercontent.com/1571635/51009300-84963600-1504-11e9-9c76-e1a6fc20c9c4.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.