### PR TITLE
test: warn developer if text domain is misspelled

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -191,4 +191,9 @@
 		<exclude name="WordPress.XSS.EscapeOutput.UnsafePrintingFunction" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 	</rule>
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="give"/>
+		</properties>
+	</rule>
 </ruleset>


### PR DESCRIPTION
## Description
This PR will fix https://github.com/impress-org/give/issues/2797

## How Has This Been Tested?

Manually Tested with Local server.

## Screenshots (jpeg or gifs if applicable):

https://www.useloom.com/share/a9880f07787541269ecf5b52ac743f91

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.