### PR TITLE
fix: log count is not correct when search for API log related to specific WP User

### DIFF
--- a/includes/admin/tools/logs/class-api-requests-logs-list-table.php
+++ b/includes/admin/tools/logs/class-api-requests-logs-list-table.php
@@ -374,7 +374,7 @@ class Give_API_Request_Log_Table extends WP_List_Table {
 		$sortable              = $this->get_sortable_columns();
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 		$this->items           = $this->get_logs();
-		$total_items           = Give()->logs->get_log_count( 0, 'api_request' );
+		$total_items           = Give()->logs->get_log_count( 0, 'api_request', $this->get_meta_query() );
 
 		$this->set_pagination_args( array(
 				'total_items' => $total_items,


### PR DESCRIPTION
## Description
This PR will fix https://github.com/impress-org/give/issues/3924

## How Has This Been Tested?
Manually Tested

## Types of changes
 Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.