### PR TITLE
fix: allow json uploads for settings import screen only on WP 5.0+ 

### DIFF
--- a/includes/admin/tools/import/class-give-import-core-settings.php
+++ b/includes/admin/tools/import/class-give-import-core-settings.php
@@ -485,6 +485,10 @@ if ( ! class_exists( 'Give_Import_Core_Settings' ) ) {
 		}
 
 		/**
+		 * Allow for json file type uploads.
+		 *
+		 * https://github.com/impress-org/give/issues/3907
+		 *
 		 * @param $file
 		 * @param $filename
 		 * @param $mimes

--- a/includes/admin/tools/import/class-give-import-core-settings.php
+++ b/includes/admin/tools/import/class-give-import-core-settings.php
@@ -456,10 +456,13 @@ if ( ! class_exists( 'Give_Import_Core_Settings' ) ) {
 			$upload = false;
 			if ( isset( $_FILES['json'] ) ) {
 				add_filter( 'upload_mimes', array( __CLASS__, 'json_upload_mimes' ) );
+				add_filter( 'wp_check_filetype_and_ext', array( __CLASS__, 'filetype_mod' ), 10, 4 );
 
 				$upload = wp_handle_upload( $_FILES['json'], array( 'test_form' => false ) );
 
 				remove_filter( 'upload_mimes', array( __CLASS__, 'json_upload_mimes' ) );
+				remove_filter( 'wp_check_filetype_and_ext', array( __CLASS__, 'filetype_mod' ), 10, 4 );
+
 			} else {
 				Give_Admin_Settings::add_error( 'give-import-csv', __( 'Please upload or provide a valid JSON file.', 'give' ) );
 			}
@@ -471,11 +474,35 @@ if ( ! class_exists( 'Give_Import_Core_Settings' ) ) {
 		 * Add mime type for JSON
 		 *
 		 * @param array $existing_mimes
+		 *
+		 * @return array
 		 */
 		public static function json_upload_mimes( $existing_mimes = array() ) {
+
 			$existing_mimes['json'] = 'application/json';
 
 			return $existing_mimes;
+		}
+
+		/**
+		 * @param $file
+		 * @param $filename
+		 * @param $mimes
+		 *
+		 * @return mixed
+		 */
+		public static function filetype_mod(  $check, $file, $filename, $mimes  ) {
+
+			if ( empty( $check['ext'] ) && empty( $check['type'] ) ) {
+				// Allow JSON uploads
+				$secondary_mime = [ 'json' => 'text/plain' ];
+
+				// Run another check, but only for our secondary mime and not on core mime types.
+				remove_filter( 'wp_check_filetype_and_ext', array(__CLASS__, 'filetype_mod'), 99, 4 );
+				$check = wp_check_filetype_and_ext( $file, $filename, $secondary_mime );
+				add_filter( 'wp_check_filetype_and_ext', array(__CLASS__, 'filetype_mod'), 99, 4 );
+			}
+			return $check;
 		}
 	}
 


### PR DESCRIPTION
## Description

Uses the fix outlined here: https://core.trac.wordpress.org/ticket/45615#comment:27 to resolved #3907 

Temporarily adds another filter to allow json uploads fro WP 5.0+ compatibility.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


Tested uploading .json file types through the settings import screen and then ensured it's not allowed by default through media uploads.


## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Bug fix
