### PR TITLE
feat: add template tag that takes donors to their subscriptions #779

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -778,3 +778,8 @@ h2.give-nav-tab-wrapper {
 	border: 4px solid white;
   }
 }
+
+
+.give_email_access_link_tag {
+	display: none;
+}

--- a/includes/admin/emails/abstract-email-notification.php
+++ b/includes/admin/emails/abstract-email-notification.php
@@ -895,16 +895,22 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 					'billing_address'         => $payment_id ? give_email_tag_billing_address( array( 'payment_id' => $payment_id ) ) : '',
 					'email_access_link'       => sprintf(
 						'<a href="%1$s">%2$s</a>',
-						give_prepare_donation_history_url( array(
+						add_query_arg(
+							array(
 								'give_nl' => uniqid(),
-                        ) ),
+							),
+							give_get_history_page_uri()
+						),
 						__( 'View your donation history &raquo;', 'give' )
 					),
 					'donation_history_link'   => sprintf(
 						'<a href="%1$s">%2$s</a>',
-						give_prepare_donation_history_url( array(
-							'give_nl' => uniqid(),
-						) ),
+						add_query_arg(
+                            array(
+                                'give_nl' => uniqid(),
+                            ),
+                            give_get_history_page_uri()
+                        ),
 						__( 'View your donation history &raquo;', 'give' )
 					),
 					'reset_password_link'     => $user_id ? give_email_tag_reset_password_link( array( 'user_id' => $user_id ), $payment_id ) : '',

--- a/includes/admin/emails/abstract-email-notification.php
+++ b/includes/admin/emails/abstract-email-notification.php
@@ -895,12 +895,16 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 					'billing_address'         => $payment_id ? give_email_tag_billing_address( array( 'payment_id' => $payment_id ) ) : '',
 					'email_access_link'       => sprintf(
 						'<a href="%1$s">%2$s</a>',
-						add_query_arg(
-							array(
+						give_prepare_donation_history_url( array(
 								'give_nl' => uniqid(),
-							),
-							give_get_history_page_uri()
-						),
+                        ) ),
+						__( 'View your donation history &raquo;', 'give' )
+					),
+					'donation_history_link'   => sprintf(
+						'<a href="%1$s">%2$s</a>',
+						give_prepare_donation_history_url( array(
+							'give_nl' => uniqid(),
+						) ),
 						__( 'View your donation history &raquo;', 'give' )
 					),
 					'reset_password_link'     => $user_id ? give_email_tag_reset_password_link( array( 'user_id' => $user_id ), $payment_id ) : '',

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -265,7 +265,7 @@ function give_get_emails_tags_list() {
 				<span class="give_<?php echo $email_tag['tag']; ?>_tag">
 					<code>{<?php echo $email_tag['tag']; ?>}</code> - <?php echo $email_tag['desc']; ?>
 				</span>
-			<?php endforeach; ?>
+            <?php endforeach; ?>
 		</div>
 	<?php
 	endif;

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -456,7 +456,13 @@ function give_setup_email_tags() {
 		array(
 			'tag'     => 'email_access_link',
 			'desc'    => esc_html__( 'The donor\'s email access link.', 'give' ),
-			'func'    => 'give_email_tag_email_access_link',
+			'func'    => 'give_email_tag_donation_history_link',
+			'context' => 'donor',
+		),
+		array(
+			'tag'     => 'donation_history_link',
+			'desc'    => esc_html__( 'The donation history link.', 'give' ),
+			'func'    => 'give_email_tag_donation_history_link',
 			'context' => 'donor',
 		),
 
@@ -1187,7 +1193,7 @@ function give_email_tag_receipt_link_url( $tag_args ) {
 }
 
 /**
- * Email template tag: {email_access_link}
+ * Email template tag: {donation_history_link}
  *
  * @since 2.0
  *
@@ -1195,7 +1201,7 @@ function give_email_tag_receipt_link_url( $tag_args ) {
  *
  * @return string
  */
-function give_email_tag_email_access_link( $tag_args ) {
+function give_email_tag_donation_history_link( $tag_args ) {
 	$donor_id          = 0;
 	$donor             = array();
 	$email_access_link = '';
@@ -1204,6 +1210,12 @@ function give_email_tag_email_access_link( $tag_args ) {
 	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
+		
+	    case ! empty( $tag_args['payment_id'] ):
+			$donor_id = Give()->payment_meta->get_meta( $tag_args['payment_id'], '_give_payment_donor_id', true );
+			$donor    = Give()->donors->get_by( 'id', $donor_id );
+			break;
+		
 		case ! empty( $tag_args['donor_id'] ):
 			$donor_id = $tag_args['donor_id'];
 			$donor    = Give()->donors->get_by( 'id', $tag_args['donor_id'] );
@@ -1231,12 +1243,9 @@ function give_email_tag_email_access_link( $tag_args ) {
 		// update donor id in email tags.
 		$tag_args['donor_id'] = $donor_id;
 
-		$access_url = add_query_arg(
-			array(
-				'give_nl' => $verify_key,
-			),
-			give_get_history_page_uri()
-		);
+		$access_url = give_prepare_donation_history_url( array(
+            'give_nl' => $verify_key,
+        ) );
 
 		// Add donation id to email access url, if it exists.
 		$donation_id = give_clean( filter_input( INPUT_GET, 'donation_id' ) );

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -1276,7 +1276,7 @@ function give_email_tag_donation_history_link( $tag_args ) {
 	} // End if().
 
 	/**
-	 * Filter the {email_access_link} email template tag output.
+	 * Filter the {donation_history_link} email template tag output.
 	 *
 	 * @since 2.0
 	 *

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -461,7 +461,7 @@ function give_setup_email_tags() {
 		),
 		array(
 			'tag'     => 'donation_history_link',
-			'desc'    => esc_html__( 'The donation history link.', 'give' ),
+			'desc'    => esc_html__( 'The donor\'s email access link for donation history.', 'give' ),
 			'func'    => 'give_email_tag_donation_history_link',
 			'context' => 'donor',
 		),

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -1243,9 +1243,12 @@ function give_email_tag_donation_history_link( $tag_args ) {
 		// update donor id in email tags.
 		$tag_args['donor_id'] = $donor_id;
 
-		$access_url = give_prepare_donation_history_url( array(
-            'give_nl' => $verify_key,
-        ) );
+		$access_url = add_query_arg(
+            array(
+                'give_nl' => $verify_key,
+            ),
+            give_get_history_page_uri()
+        );
 
 		// Add donation id to email access url, if it exists.
 		$donation_id = give_clean( filter_input( INPUT_GET, 'donation_id' ) );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2478,3 +2478,25 @@ function give_display_donation_receipt( $args ) {
 	
 	return ob_get_clean();
 }
+
+/**
+ * This function is used to prepare url with query strings on top of donation history url.
+ *
+ * @param bool|array $args List of query strings to be added.
+ *
+ * @since 2.4.1
+ *
+ * @return string
+ */
+function give_prepare_donation_history_url( $args = false ) {
+	
+	$url = give_get_history_page_uri();
+ 
+	// If $args is array then add query string to URL.
+    if ( is_array( $args ) ) {
+	    $url = add_query_arg( $args , give_get_history_page_uri() );
+    }
+	
+	return esc_url( $url );
+ 
+}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2478,25 +2478,3 @@ function give_display_donation_receipt( $args ) {
 	
 	return ob_get_clean();
 }
-
-/**
- * This function is used to prepare url with query strings on top of donation history url.
- *
- * @param bool|array $args List of query strings to be added.
- *
- * @since 2.4.1
- *
- * @return string
- */
-function give_prepare_donation_history_url( $args = false ) {
-	
-	$url = give_get_history_page_uri();
- 
-	// If $args is array then add query string to URL.
-    if ( is_array( $args ) ) {
-	    $url = add_query_arg( $args , give_get_history_page_uri() );
-    }
-	
-	return esc_url( $url );
- 
-}

--- a/tests/unit-tests/tests-email-tags.php
+++ b/tests/unit-tests/tests-email-tags.php
@@ -682,12 +682,12 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 
 
 	/**
-	 * Test function give_email_tag_email_access_link
+	 * Test function give_email_tag_donation_history_link
 	 *
 	 * @since 2.0
-	 * @cover give_email_tag_email_access_link
+	 * @cover give_email_tag_donation_history_link
 	 */
-	function test_give_email_tag_email_access_link() {
+	function test_give_email_tag_donation_history_link() {
 		// Create new table columns manually.
 		// Are db columns setup?
 		if( ! Give()->donors->does_column_exist( 'token' ) ) {
@@ -696,7 +696,7 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 
 		Give_Helper_Payment::create_simple_payment();
 
-		$link = give_email_tag_email_access_link( array( 'user_id' => 1 ) );
+		$link = give_email_tag_donation_history_link( array( 'user_id' => 1 ) );
 
 		$this->assertRegExp(
 			'/target="_blank">View your donation history &raquo;<\/a>/',
@@ -708,7 +708,7 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 			$link
 		);
 
-		$link = give_email_tag_email_access_link( array( 'user_id' => 1, 'email_content_type' => 'text/plain' ) );
+		$link = give_email_tag_donation_history_link( array( 'user_id' => 1, 'email_content_type' => 'text/plain' ) );
 
 		$this->assertRegExp(
 			'/View your donation history: .+?\?give_nl=/',


### PR DESCRIPTION
## Description
This PR resolves #779 

## How Has This Been Tested?
I've tested this PR by processing the recurring donation and checking the email tags as per the issue description and acceptance criteria.

**Note:** Merge Pr https://github.com/impress-org/give/pull/3984 for `{subscriptions_link}` email tag

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/52204790-21958600-289b-11e9-9687-04133a4072d6.png)

Email Tag ( Email access email tag is not shown in the list however it will work as backward compatibility)
![image](https://user-images.githubusercontent.com/1852711/52205064-ec3d6800-289b-11e9-89da-1464e83c7b2e.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
