### PR TITLE
fix: improve focus behavior in multi-level forms #3889

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -177,8 +177,8 @@ jQuery( function( $ ) {
 		$( this ).parent( '.give-donation-amount' ).addClass( 'give-custom-amount-focus-in' );
 
 		//Set Multi-Level to Custom Amount Field
-		parent_form.find( '.give-default-level, .give-radio-input' ).removeClass( 'give-default-level' );
-		parent_form.find( '.give-btn-level-custom' ).addClass( 'give-default-level' );
+		parent_form.find( '.give-selected-level, .give-radio-input' ).removeClass( 'give-selected-level' );
+		parent_form.find( '.give-btn-level-custom' ).addClass( 'give-selected-level' );
 		parent_form.find( '.give-radio-input' ).prop( 'checked', false ); // Radio
 		parent_form.find( '.give-radio-input.give-radio-level-custom' ).prop( 'checked', true ); // Radio
 		parent_form.find( '.give-select-level' ).prop( 'selected', false ); // Select
@@ -218,7 +218,7 @@ jQuery( function( $ ) {
 			}
 		}
 
-		// Cache donor selected price id for a amount.
+		// Cache donor selected price id for an amount.
 		Give.fn.setCache( 'amount_' + value_now, price_id, parent_form );
 		$( this ).val( formatted_total );
 
@@ -288,7 +288,7 @@ jQuery( function( $ ) {
 			parent_form.find( '.give-amount-hidden' ).val( Give.form.fn.formatAmount( value_now, parent_form, {} ) );
 
 			// Remove old selected class & add class for CSS purposes
-			parent_form.find( '.give-default-level' ).removeClass( 'give-default-level' );
+			parent_form.find( '.give-selected-level' ).removeClass( 'give-selected-level' );
 
 			// Auto select variable price items ( Radio/Button/Select ).
 			Give.form.fn.autoSelectDonationLevel( parent_form, price_id );
@@ -298,8 +298,8 @@ jQuery( function( $ ) {
 		$( this ).parent( '.give-donation-amount' )
 			.removeClass( 'give-custom-amount-focus-in' );
 
-		// trigger an event for hooks
-		jQuery( document ).trigger( 'give_donation_value_updated', [ parent_form, value_now, price_id ] );
+		// Trigger an event for hooks
+		$( document ).trigger( 'give_donation_value_updated', [ parent_form, value_now, price_id ] );
 
 	} );
 

--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -177,8 +177,8 @@ jQuery( function( $ ) {
 		$( this ).parent( '.give-donation-amount' ).addClass( 'give-custom-amount-focus-in' );
 
 		//Set Multi-Level to Custom Amount Field
-		parent_form.find( '.give-selected-level, .give-radio-input' ).removeClass( 'give-selected-level' );
-		parent_form.find( '.give-btn-level-custom' ).addClass( 'give-selected-level' );
+		parent_form.find( '.give-default-level, .give-radio-input' ).removeClass( 'give-default-level' );
+		parent_form.find( '.give-btn-level-custom' ).addClass( 'give-default-level' );
 		parent_form.find( '.give-radio-input' ).prop( 'checked', false ); // Radio
 		parent_form.find( '.give-radio-input.give-radio-level-custom' ).prop( 'checked', true ); // Radio
 		parent_form.find( '.give-select-level' ).prop( 'selected', false ); // Select
@@ -288,7 +288,7 @@ jQuery( function( $ ) {
 			parent_form.find( '.give-amount-hidden' ).val( Give.form.fn.formatAmount( value_now, parent_form, {} ) );
 
 			// Remove old selected class & add class for CSS purposes
-			parent_form.find( '.give-selected-level' ).removeClass( 'give-selected-level' );
+			parent_form.find( '.give-default-level' ).removeClass( 'give-default-level' );
 
 			// Auto select variable price items ( Radio/Button/Select ).
 			Give.form.fn.autoSelectDonationLevel( parent_form, price_id );

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -477,7 +477,7 @@ export default {
 						.prop( 'checked', false );
 					$form.find( '.give-radio-input[data-price-id="' + price_id + '"]' )
 						.prop( 'checked', true )
-						.addClass( 'give-default-level' );
+						.addClass( 'give-selected-level' );
 					break;
 
 				// Set focus to price id button.
@@ -485,8 +485,7 @@ export default {
 					$form.find( 'button.give-donation-level-btn' )
 						.blur();
 					$form.find( 'button.give-donation-level-btn[data-price-id="' + price_id + '"]' )
-						.focus()
-						.addClass( 'give-default-level' );
+						.addClass( 'give-selected-level' );
 					break;
 
 				// Auto select option.
@@ -495,7 +494,7 @@ export default {
 						.prop( 'selected', false );
 					$form.find( 'select.give-select-level option[data-price-id="' + price_id + '"]' )
 						.prop( 'selected', true )
-						.addClass( 'give-default-level' );
+						.addClass( 'give-selected-level' );
 					break;
 
 			}

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -477,7 +477,7 @@ export default {
 						.prop( 'checked', false );
 					$form.find( '.give-radio-input[data-price-id="' + price_id + '"]' )
 						.prop( 'checked', true )
-						.addClass( 'give-selected-level' );
+						.addClass( 'give-default-level' );
 					break;
 
 				// Set focus to price id button.
@@ -485,7 +485,7 @@ export default {
 					$form.find( 'button.give-donation-level-btn' )
 						.blur();
 					$form.find( 'button.give-donation-level-btn[data-price-id="' + price_id + '"]' )
-						.addClass( 'give-selected-level' );
+						.addClass( 'give-default-level' );
 					break;
 
 				// Auto select option.
@@ -494,7 +494,7 @@ export default {
 						.prop( 'selected', false );
 					$form.find( 'select.give-select-level option[data-price-id="' + price_id + '"]' )
 						.prop( 'selected', true )
-						.addClass( 'give-selected-level' );
+						.addClass( 'give-default-level' );
 					break;
 
 			}

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -529,7 +529,7 @@ function give_output_levels( $form_id ) {
 
 			foreach ( $prices as $price ) {
 				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
-				$level_classes = apply_filters( 'give_form_level_classes', 'give-donation-level-btn give-btn give-btn-level-' . $price['_give_id']['level_id'] . ' ' . ( give_is_default_level_id( $price ) ? 'give-default-level' : '' ), $form_id, $price );
+				$level_classes = apply_filters( 'give_form_level_classes', 'give-donation-level-btn give-btn give-btn-level-' . $price['_give_id']['level_id'] . ' ' . ( give_is_default_level_id( $price ) ? 'give-default-level give-selected-level' : '' ), $form_id, $price );
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'], array(
@@ -569,7 +569,7 @@ function give_output_levels( $form_id ) {
 
 			foreach ( $prices as $price ) {
 				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
-				$level_classes = apply_filters( 'give_form_level_classes', 'give-radio-input give-radio-input-level give-radio-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level' : '' ), $form_id, $price );
+				$level_classes = apply_filters( 'give_form_level_classes', 'give-radio-input give-radio-input-level give-radio-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level give-selected-level' : '' ), $form_id, $price );
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'], array(
@@ -612,7 +612,7 @@ function give_output_levels( $form_id ) {
 			foreach ( $prices as $price ) {
 				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
 				$level_classes = apply_filters(
-					'give_form_level_classes', 'give-donation-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level' : '' ), $form_id,
+					'give_form_level_classes', 'give-donation-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level give-selected-level' : '' ), $form_id,
 					$price
 				);
 

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -529,7 +529,7 @@ function give_output_levels( $form_id ) {
 
 			foreach ( $prices as $price ) {
 				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
-				$level_classes = apply_filters( 'give_form_level_classes', 'give-donation-level-btn give-btn give-btn-level-' . $price['_give_id']['level_id'] . ' ' . ( give_is_default_level_id( $price ) ? 'give-default-level give-selected-level' : '' ), $form_id, $price );
+				$level_classes = apply_filters( 'give_form_level_classes', 'give-donation-level-btn give-btn give-btn-level-' . $price['_give_id']['level_id'] . ' ' . ( give_is_default_level_id( $price ) ? 'give-default-level' : '' ), $form_id, $price );
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'], array(
@@ -569,7 +569,7 @@ function give_output_levels( $form_id ) {
 
 			foreach ( $prices as $price ) {
 				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
-				$level_classes = apply_filters( 'give_form_level_classes', 'give-radio-input give-radio-input-level give-radio-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level give-selected-level' : '' ), $form_id, $price );
+				$level_classes = apply_filters( 'give_form_level_classes', 'give-radio-input give-radio-input-level give-radio-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level' : '' ), $form_id, $price );
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'], array(
@@ -612,7 +612,7 @@ function give_output_levels( $form_id ) {
 			foreach ( $prices as $price ) {
 				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
 				$level_classes = apply_filters(
-					'give_form_level_classes', 'give-donation-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level give-selected-level' : '' ), $form_id,
+					'give_form_level_classes', 'give-donation-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level' : '' ), $form_id,
 					$price
 				);
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

There are two changes of note in this PR to resolve #3889:

**Change 1**

In this PR I ensure that `.give-default-level` CSS class **remains** on the _default level_ selected in the admin interface:

![2019-02-06_20-37-52](https://user-images.githubusercontent.com/1571635/52390767-184d1a80-2a4f-11e9-80bd-0e27bc5f8b98.png)

Previously, this class was switched to the level the user selected. The problem with this is that the naming implied it was meant for only the default level and shouldn't have been changed. For instance, if I wanted to add special styling to the default level I would think I could use this class. However, previous to this PR that wasn't the case.

To resolve this I've added a new CSS class `.give-selected-level`. In this PR this CSS class is switched to the selected level.

**Note: The downside of this PR is that we're most likely going to break some existing custom styles for themes using the `.give-default-level` class to style the selected class. However, it's an easy fix so I think it's worth it.

**Change 2**

I've also removed the `.focus()` method that fires for donors who focus out of the custom amount field to prevent the unnecessary two clicks to get into another field.

The only reason I could see this was required was to get the focus CSS to display again on the appropriate level. However, with the addition of `.give-selected-level` this is no longer necessary as long as you provide styles using this new class.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually

## Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix
<!-- New feature (non-breaking change which adds functionality) -->
- Breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.