### PR TITLE
fix: ensure the form title displays properly for widgets

### DIFF
--- a/assets/src/css/admin/goals.scss
+++ b/assets/src/css/admin/goals.scss
@@ -29,3 +29,21 @@
   }
 }
 
+#give-form-goal-stats {
+
+  .inside {
+	margin:0;
+	padding: 15px;
+	text-align: center;
+  }
+
+  .give-admin-progress-bar {
+	margin-bottom: 10px;
+  }
+
+  .give-admin-goal-achieved {
+	display:block;
+	margin-top: 6px;
+  }
+
+}

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -154,7 +154,7 @@ jQuery(
  */
 window.give_open_form_modal = function ($form_wrap, $form) {
 
-	// Don't his these form children elements.
+	// Don't hide these form children elements.
 	var children = '#give_purchase_form_wrap, #give-payment-mode-select, .mfp-close, .give-hidden, .give-form-title';
 
 	jQuery.magnificPopup.open(
@@ -175,8 +175,8 @@ window.give_open_form_modal = function ($form_wrap, $form) {
 					var $form_title   = jQuery( '.give-form-title', $form_wrap );
 
 					// Modal Display
-					if ($form_wrap.hasClass( 'give-display-modal' ) && ! $form.data( 'content' )) {
-
+					if ($form_wrap.hasClass( 'give-modal' ) && ! $form.data( 'content' )) {
+						
 						// Add title container to form.
 						if ($form_title.length && ! jQuery( '.give-form-title', $form ).length) {
 							$form.prepend( $form_title );
@@ -187,8 +187,7 @@ window.give_open_form_modal = function ($form_wrap, $form) {
 					} else if ($form_wrap.hasClass( 'give-display-button-only' ) && ! $form.data( 'content' )) {
 
 						// Button Display:
-						// add title, content, goal and error to form if admin want to show button only
-
+						// add title, content, goal and error to form.
 						var $form_content = jQuery( '.give-form-content-wrap', $form_wrap ),
 							$form_goal    = jQuery( '.give-goal-progress', $form_wrap ),
 							$form_error   = jQuery( '>.give_error', $form_wrap ),

--- a/blocks/donation-form/class-give-donation-form-block.php
+++ b/blocks/donation-form/class-give-donation-form-block.php
@@ -4,7 +4,7 @@
  *
  * @package     Give
  * @subpackage  Classes/Blocks
- * @copyright   Copyright (c) 2016, GiveWP
+ * @copyright   Copyright (c) 2018, GiveWP
  * @license     https://opensource.org/licenses/gpl-license GNU Public License
  * @since       2.0.2
  */
@@ -80,46 +80,48 @@ class Give_Donation_Form_Block {
 	 */
 	public function register_block() {
 		// Bailout.
-		if( ! function_exists('register_block_type' ) ) {
+		if ( ! function_exists( 'register_block_type' ) ) {
 			return;
 		}
 
 		// Register block.
-		register_block_type( 'give/donation-form', array(
-			'render_callback' => array( $this, 'render_donation_form' ),
-			'attributes'      => array(
-				'id'	=> array(
-					'type' => 'number',
+		register_block_type(
+			'give/donation-form', array(
+				'render_callback' => array( $this, 'render_donation_form' ),
+				'attributes'      => array(
+					'id'                  => array(
+						'type' => 'number',
+					),
+					'prevId'              => array(
+						'type' => 'number',
+					),
+					'displayStyle'        => array(
+						'type'    => 'string',
+						'default' => 'onpage',
+					),
+					'continueButtonTitle' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'showTitle'           => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showGoal'            => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'contentDisplay'      => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'showContent'         => array(
+						'type'    => 'string',
+						'default' => 'above',
+					),
 				),
-				'prevId'	=> array(
-					'type' => 'number',
-				),
-				'displayStyle'	=> array(
-					'type' => 'string',
-					'default' => 'onpage',
-				),
-				'continueButtonTitle' => array(
-					'type' => 'string',
-					'default' => '',
-				),
-				'showTitle'	=> array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'showGoal'            => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'contentDisplay' => array(
-					'type' => 'boolean',
-					'default' => false,
-				),
-				'showContent'         => array(
-					'type'    => 'string',
-					'default' => 'above',
-				),
-			),
-		) );
+			)
+		);
 	}
 
 	/**

--- a/blocks/donation-form/data/attributes.js
+++ b/blocks/donation-form/data/attributes.js
@@ -1,7 +1,6 @@
 /**
  * Block Attributes
 */
-
 const blockAttributes = {
 	id: {
 		type: 'number',
@@ -19,15 +18,15 @@ const blockAttributes = {
 	},
 	showTitle: {
 		type: 'boolean',
-		default: false,
+		default: true,
 	},
 	showGoal: {
 		type: 'boolean',
-		default: false,
+		default: true,
 	},
 	contentDisplay: {
 		type: 'boolean',
-		default: false,
+		default: true,
 	},
 	showContent: {
 		type: 'string',

--- a/blocks/donation-form/edit/inspector.js
+++ b/blocks/donation-form/edit/inspector.js
@@ -14,7 +14,6 @@ import giveFormOptions from '../data/options';
 /**
  * Render Inspector Controls
 */
-
 class Inspector extends Component {
 	constructor( props ) {
 		super( props );

--- a/blocks/donor-wall/edit/inspector.js
+++ b/blocks/donor-wall/edit/inspector.js
@@ -85,7 +85,7 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					onChange={ ( value ) => saveSetting( 'showAnonymous', value ) } />
 				<ToggleControl
 					name="onlyComments"
-					label={ __( 'Donor With Comments' ) }
+					label={ __( 'Only Donors with Comments' ) }
 					checked={ !! onlyComments }
 					onChange={ ( value ) => saveSetting( 'onlyComments', value ) } />
 				<TextControl

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -108,7 +108,7 @@ function give_get_donation_form( $args = array() ) {
 			 */
 			$form_title = apply_filters( 'give_form_title', '<h2 class="give-form-title">' . get_the_title( $form_id ) . '</h2>' );
 
-			if ( ! doing_action( 'give_single_form_summary' ) ) {
+			if ( ! doing_action( 'give_single_form_summary' ) && true === $args['show_title'] ) {
 				echo $form_title;
 			}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

The form title will not appear in these cases because it is already displayed on page:

- Modal does NOT display the form title for **form widgets**
- Modal does NOT display the form title for **modal shortcodes**

The form title will display for these cases because it has not been displayed yet:

- Modal DOES display form title for **form grid**
- Modal DOES display form title for **button mode shortcodes**

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.