### PR TITLE
fix: "state" text appearing twice on donor detail screen #3995

### DIFF
--- a/includes/admin/class-give-html-elements.php
+++ b/includes/admin/class-give-html-elements.php
@@ -623,8 +623,11 @@ class Give_HTML_Elements {
 		}
 
 		$output = '<span id="give-' . sanitize_key( $args['name'] ) . '-wrap">';
-
-		$output .= '<label class="give-label" for="give-' . sanitize_key( $args['name'] ) . '">' . esc_html( $args['label'] ) . '</label>';
+		
+		// Don't output label when the label is empty.
+		if ( ! empty( $args['label'] ) ) {
+			$output .= '<label class="give-label" for="give-' . sanitize_key( $args['name'] ) . '">' . esc_html( $args['label'] ) . '</label>';
+		}
 
 		if ( ! empty( $args['desc'] ) ) {
 			$output .= '<span class="give-description">' . esc_html( $args['desc'] ) . '</span>';


### PR DESCRIPTION
## Description
This PR resolves #3995 

## How Has This Been Tested?
I've tested this PR as per the acceptance criteria on the issue.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/52930271-c91bb980-336d-11e9-80f7-7fd8c101d540.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.