### PR TITLE
Feature/give update donor information post create filter

### DIFF
--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -747,14 +747,16 @@ final class Give_Payment {
 			 */
 			$donor = apply_filters( 'give_update_donor_information_post_create', $donor, $payment_id, $payment_data, $args );
 
-			// Update Donor Meta once donor is created.
-			$donor->update_meta( '_give_donor_first_name', $this->first_name );
-			$donor->update_meta( '_give_donor_last_name', $this->last_name );
-			$donor->update_meta( '_give_donor_title_prefix', $this->title_prefix );
+			if ( ! empty( $donor->id ) ) {
+				// Update Donor Meta once donor is created.
+				$donor->update_meta( '_give_donor_first_name', $this->first_name );
+				$donor->update_meta( '_give_donor_last_name', $this->last_name );
+				$donor->update_meta( '_give_donor_title_prefix', $this->title_prefix );
 
-			$this->customer_id            = $donor->id;
-			$this->pending['customer_id'] = $this->customer_id;
-			$donor->attach_payment( $this->ID, false );
+				$this->customer_id            = $donor->id;
+				$this->pending['customer_id'] = $this->customer_id;
+				$donor->attach_payment( $this->ID, false );
+			}
 
 			$this->payment_meta = apply_filters( 'give_payment_meta', $this->payment_meta, $payment_data );
 

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -735,6 +735,18 @@ final class Give_Payment {
 
 			}
 
+			/**
+			 * Filter donor class after the donor is retrieved. Useful if you do not want to update an existing donor with payment data.
+			 *
+			 * @since 2.5.0
+			 *
+			 * @param stdClass $donor        Donor class.
+			 * @param int      $payment_id   Payment ID.
+			 * @param array    $payment_data Payment data array.
+			 * @param array    $args         Payment args.
+			 */
+			$donor = apply_filters( 'give_update_donor_information_post_create', $donor, $payment_id, $payment_data, $args );
+
 			// Update Donor Meta once donor is created.
 			$donor->update_meta( '_give_donor_first_name', $this->first_name );
 			$donor->update_meta( '_give_donor_last_name', $this->last_name );


### PR DESCRIPTION
## Description
Adds a filter to modify the `$donor` object after retrieving/creating it.

Use case: we’re building a plugin to add matching donations and the match donations should not be credited to the original donor.

## How Has This Been Tested?
Tested on a local WordPress installation.

## Types of changes

New feature: adds a new filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.