### PR TITLE
add filter just after retrieving logged-in donor

### DIFF
--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -713,6 +713,18 @@ final class Give_Payment {
 			if ( did_action( 'give_pre_process_donation' ) && is_user_logged_in() ) {
 				$donor = new Give_Donor( get_current_user_id(), true );
 
+				/**
+				 * Filter donor class after the donation is completed and after retrieving the logged-in user and before customer table is updated.
+				 *
+				 * @since 2.5.0
+				 *
+				 * @param Give_Donor $donor        Donor object.
+				 * @param int        $payment_id   Payment ID.
+				 * @param array      $payment_data Payment data array.
+				 * @param array      $args         Payment args.
+				 */
+				$donor = apply_filters( 'give_update_donor_information_logged_in_user', $donor, $payment_id, $payment_data, $args );
+
 				// Donor is logged in but used a different email to purchase with so assign to their donor record.
 				if ( ! empty( $donor->id ) && $this->email !== $donor->email ) {
 					$donor->add_email( $this->email );


### PR DESCRIPTION
## Description
Adds a filter to modify the `$donor` object after retrieving it from the logged-in user.
Similar to https://github.com/impress-org/give/pull/4016 but seems cleaner/more logical since this can be used in tandem with the `give_update_donor_information` filter to do the same thing.

Use case: we’re building a plugin to add matching donations and the match donations should not be credited to the original donor.

## How Has This Been Tested?
Tested on a local WordPress installation.

## Types of changes

New feature: adds a new filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.