### PR TITLE
fix: stop loading donor notes when create Give_donor object #3994

### DIFF
--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -121,7 +121,7 @@ class Give_Donor {
 	 *
 	 * @var    array
 	 */
-	public $notes;
+	protected $notes = null;
 
 	/**
 	 * Donor address.
@@ -202,7 +202,6 @@ class Give_Donor {
 				switch ( $key ) {
 
 					case 'notes':
-						$this->$key = $this->get_notes();
 						break;
 
 					default:

--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -201,6 +201,8 @@ class Give_Donor {
 
 				switch ( $key ) {
 
+					// @todo We will remove this statement when we will remove notes column from donor table
+					// https://github.com/impress-org/give/issues/3632
 					case 'notes':
 						break;
 


### PR DESCRIPTION
## Description
This pr will resolve #3994 

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/1784821/52459635-56038d80-2b8c-11e9-9930-8f7dceecce11.png)

You will see mentioned SQL query when you visit a single donation form page.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.