### PR TITLE
fix: ensure do not set default autocomplete on every dropdown fields #4028

### DIFF
--- a/includes/admin/class-give-html-elements.php
+++ b/includes/admin/class-give-html-elements.php
@@ -455,6 +455,7 @@ class Give_HTML_Elements {
 			'name'             => null,
 			'class'            => '',
 			'id'               => '',
+			'autocomplete'     => '',
 			'selected'         => 0,
 			'chosen'           => false,
 			'placeholder'      => null,
@@ -489,14 +490,15 @@ class Give_HTML_Elements {
 		}
 
 		$output = sprintf(
-			'<select name="%1$s" id="%2$s" autocomplete="address-level4" class="give-select %3$s" %4$s %5$s placeholder="%6$s" data-placeholder="%6$s" %7$s>',
+			'<select name="%1$s" id="%2$s" autocomplete="%8$s" class="give-select %3$s" %4$s %5$s placeholder="%6$s" data-placeholder="%6$s" %7$s>',
 			esc_attr( $args['name'] ),
 			esc_attr( sanitize_key( str_replace( '-', '_', $args['id'] ) ) ),
 			esc_attr( $args['class'] ),
 			$multiple,
 			$args['select_atts'],
 			$placeholder,
-			$data_elements
+			$data_elements,
+			$args['autocomplete']
 		);
 
 		if ( $args['show_option_all'] ) {

--- a/includes/admin/class-give-html-elements.php
+++ b/includes/admin/class-give-html-elements.php
@@ -455,7 +455,7 @@ class Give_HTML_Elements {
 			'name'             => null,
 			'class'            => '',
 			'id'               => '',
-			'autocomplete'     => '',
+			'autocomplete'     => 'no',
 			'selected'         => 0,
 			'chosen'           => false,
 			'placeholder'      => null,

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -633,6 +633,7 @@ function give_donor_view( $donor ) {
 										'chosen'           => true,
 										'placeholder'      => esc_attr__( 'Select a country', 'give' ),
 										'data'             => array( 'search-type' => 'no_ajax' ),
+										'autocomplete'     => 'country',
 									) );
 									?>
 								</td>
@@ -676,8 +677,9 @@ function give_donor_view( $donor ) {
 										<?php
 										$states     = give_get_states( $base_country );
 										$state_args = array(
-											'name'  => 'state',
-											'class' => 'regular-text',
+											'name'         => 'state',
+											'class'        => 'regular-text',
+											'autocomplete' => 'address-level1',
 										);
 
 										if ( empty( $states ) ) {

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -749,6 +749,7 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 																'chosen'           => true,
 																'placeholder'      => esc_attr__( 'Select a country', 'give' ),
 																'data'             => array( 'search-type' => 'no_ajax' ),
+																'autocomplete'     => 'country',
 															)
 														);
 														?>
@@ -796,11 +797,12 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 																		'chosen'           => true,
 																		'placeholder'      => esc_attr__( 'Select a state', 'give' ),
 																		'data'             => array( 'search-type' => 'no_ajax' ),
+																		'autocomplete' => 'address-level1',
 																	)
 																);
 															} else {
 																?>
-																<input id="give-payment-address-state" type="text" name="give-payment-address[0][state]" value="<?php echo esc_attr( $address['state'] ); ?>" class="medium-text"/>
+																<input id="give-payment-address-state" type="text" name="give-payment-address[0][state]" autocomplete="address-line1" value="<?php echo esc_attr( $address['state'] ); ?>" class="medium-text"/>
 																<?php
 															}
 															?>

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -239,7 +239,7 @@ function give_ajax_get_states_field() {
 
 	$states = give_get_states( $country );
 	if ( ! empty( $states ) ) {
-		$args         = array(
+		$args = array(
 			'name'             => $field_name,
 			'id'               => $field_name,
 			'class'            => $field_name . '  give-select',
@@ -248,6 +248,7 @@ function give_ajax_get_states_field() {
 			'show_option_none' => false,
 			'placeholder'      => $label,
 			'selected'         => $default_state,
+			'autocomplete'     => 'address-level1',
 		);
 		$data         = Give()->html->select( $args );
 		$states_found = true;


### PR DESCRIPTION
## Description
This PR will fix #4028 

## How Has This Been Tested?
By checking  `Give_HTML_Element::select` output with various param.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.