### PR TITLE
fix: prevent warning in System Info host detection #4041

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -351,8 +351,6 @@ function give_get_host() {
 		$host = 'ICDSoft';
 	} elseif ( DB_HOST == 'mysqlv5' ) {
 		$host = 'NetworkSolutions';
-	} elseif ( strpos( $find_host, preg_match('wp', $find_host) ) ) {
-		$host = "Bluehost";
 	} elseif ( strpos( DB_HOST, 'ipagemysql.com' ) !== false ) {
 		$host = 'iPage';
 	} elseif ( strpos( DB_HOST, 'ipowermysql.com' ) !== false ) {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes #4041 by removing an incorrect use of `preg_match()` which was causing an error. I could not see any scenario in which the return value of `preg_match()` which is `0`, `1`, or `false` would make sense when used within `strpos()`.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Visited System Info screen in Local by Flywheel and confirmed the default case renders correctly.
- Confirmed the System Info also copies without errors included in the content.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.