### PR TITLE
fix: resolve PHP warning on PHP 7.3 in email-tags file #4044

### DIFF
--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -1628,7 +1628,7 @@ function __give_render_metadata_email_tag( $content, $tag_args ) {
 					// Bailout.
 					if ( ! isset( $tag_args['payment_id'] ) ) {
 						$replace[] = '';
-						continue;
+						continue 2;
 					}
 
 					$meta_data = give_get_meta( absint( $tag_args['payment_id'] ), $meta_name, true, '' );


### PR DESCRIPTION
## Description
This PR will resolve #4044 

## How Has This Been Tested?
Tested with PHP7.3.
[x] Visit admin pages without any notice.
[x] I am able to process donation without any issue.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.