### PR TITLE
fix: display donations made in 2019 when the site date format is set to d/m/Y #4088

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -922,7 +922,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 			: date( 'Y-m-d', 0 );
 		$end_date   = ! empty( $_GET['end-date'] )
 			? sanitize_text_field( $_GET['end-date'] )
-			: date( give_date_format(), current_time( 'timestamp' ) );
+			: date( 'Y-m-d', current_time( 'timestamp' ) );
 		$form_id    = ! empty( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : null;
 		$gateway    = ! empty( $_GET['gateway'] ) ? give_clean( $_GET['gateway'] ) : null;
 


### PR DESCRIPTION
## Description
This pr will resolve #4088 

## How Has This Been Tested?
https://www.loom.com/share/407a6df7dc504b8598df6b0890a026a7

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.