### PR TITLE
fix: update Nonce verification error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Give relies on several npm commands to get you started:
 * `npm run dev` - Runs a one time build for development. No production files are created.
 * `npm run production` - Builds the minified production files for release.
 
+##### Note only compatible with Node 10
+
 ### Development Notes
 
 * Ensure that you have `SCRIPT_DEBUG` enabled within your wp-config.php file. Here's a good example of wp-config.php for debugging:

--- a/includes/admin/donors/donor-actions.php
+++ b/includes/admin/donors/donor-actions.php
@@ -386,7 +386,7 @@ function give_add_donor_email( $args ) {
 	} elseif ( ! wp_verify_nonce( $args['_wpnonce'], 'give_add_donor_email' ) ) {
 		$output = array(
 			'success' => false,
-			'message' => __( 'Nonce verification failed.', 'give' ),
+			'message' => __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ),
 		);
 	} elseif ( ! is_email( $args['email'] ) ) {
 		$output = array(
@@ -464,7 +464,7 @@ function give_remove_donor_email() {
 
 	$nonce = $_GET['_wpnonce'];
 	if ( ! wp_verify_nonce( $nonce, 'give-remove-donor-email' ) ) {
-		wp_die( __( 'Nonce verification failed', 'give' ), __( 'Error', 'give' ), array(
+		wp_die( __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), __( 'Error', 'give' ), array(
 			'response' => 403,
 		) );
 	}
@@ -511,7 +511,7 @@ function give_set_donor_primary_email() {
 	$nonce = $_GET['_wpnonce'];
 
 	if ( ! wp_verify_nonce( $nonce, 'give-set-donor-primary-email' ) ) {
-		wp_die( __( 'Nonce verification failed', 'give' ), __( 'Error', 'give' ), array(
+		wp_die( __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), __( 'Error', 'give' ), array(
 			'response' => 403,
 		) );
 	}

--- a/includes/admin/forms/class-give-form-duplicator.php
+++ b/includes/admin/forms/class-give-form-duplicator.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'Give_Form_Duplicator' ) ) {
 
 			} elseif ( ! wp_verify_nonce( give_clean( $_REQUEST['_wpnonce'] ), 'give-duplicate-form' ) ) {
 
-				wp_die( esc_html__( 'Nonce verification failed', 'give' ) );
+				wp_die( esc_html__( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ) );
 			}
 			// @codingStandardsIgnoreEnd
 

--- a/includes/admin/tools/export/export-actions.php
+++ b/includes/admin/tools/export/export-actions.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function give_process_batch_export_form() {
 
 	if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'give-batch-export' ) ) {
-		wp_die( esc_html__( 'Nonce verification failed.', 'give' ), esc_html__( 'Error', 'give' ), array(
+		wp_die( esc_html__( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), esc_html__( 'Error', 'give' ), array(
 			'response' => 403,
 		) );
 	}

--- a/includes/admin/tools/export/pdf-reports.php
+++ b/includes/admin/tools/export/pdf-reports.php
@@ -32,7 +32,7 @@ function give_generate_pdf( $data ) {
 	}
 
 	if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'give_generate_pdf' ) ) {
-		wp_die( __( 'Nonce verification failed.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	if ( ! file_exists( GIVE_PLUGIN_DIR . '/includes/libraries/give-pdf.php' ) ) {

--- a/includes/api/class-give-api.php
+++ b/includes/api/class-give-api.php
@@ -1865,7 +1865,7 @@ class Give_API {
 	public function process_api_key( $args ) {
 
 		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'give-api-nonce' ) ) {
-			wp_die( __( 'Nonce verification failed.', 'give' ), __( 'Error', 'give' ), array(
+			wp_die( __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), __( 'Error', 'give' ), array(
 				'response' => 403,
 			) );
 		}

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -793,7 +793,7 @@ function give_validate_nonce( $nonce, $action = - 1, $wp_die_args = array() ) {
 		$wp_die_args = wp_parse_args(
 			$wp_die_args,
 			array(
-				'message' => __( 'Nonce verification has failed.', 'give' ),
+				'message' => __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ),
 				'title'   => __( 'Error', 'give' ),
 				'args'    => array(
 					'response' => 403,
@@ -830,7 +830,7 @@ function give_verify_donation_form_nonce( $nonce = '', $form_id ) {
 	$verify_nonce = give_validate_nonce( $nonce, $nonce_action );
 
 	if ( ! $verify_nonce ) {
-		give_set_error( 'donation_form_nonce', __( 'Nonce verification has failed.', 'give' ) );
+		give_set_error( 'donation_form_nonce', __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ) );
 	}
 
 	return $verify_nonce;

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -317,7 +317,7 @@ function give_listen_for_failed_payments() {
 
 	// Security check.
 	if ( ! wp_verify_nonce( $nonce, "give-failed-donation-{$payment_id}" ) ) {
-		wp_die( __( 'Nonce verification failed.', 'give' ), __( 'Error', 'give' ) );
+		wp_die( __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), __( 'Error', 'give' ) );
 	}
 
 	// Set payment status to failure

--- a/includes/gateways/actions.php
+++ b/includes/gateways/actions.php
@@ -45,7 +45,7 @@ function give_load_ajax_gateway() {
 		! isset( $post_data['nonce'] )
 		|| ! give_verify_donation_form_nonce( $post_data['nonce'], $post_data['give_form_id'] )
 	) {
-		Give_Notices::print_frontend_notice( __( 'Nonce verification has failed.', 'give' ), true, 'error' );
+		Give_Notices::print_frontend_notice( __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), true, 'error' );
 		exit();
 
 	}elseif ( isset( $post_data['give_payment_mode'] ) ) {

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -35,7 +35,7 @@ add_action( 'give_manual_cc_form', '__return_false' );
 function give_manual_payment( $purchase_data ) {
 
 	if ( ! wp_verify_nonce( $purchase_data['gateway_nonce'], 'give-gateway' ) ) {
-		wp_die( esc_html__( 'Nonce verification failed.', 'give' ), esc_html__( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( esc_html__( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ), esc_html__( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	//Create payment_data array

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -846,7 +846,7 @@ function give_donation_form_validate_new_user() {
 
 	// Validate user creation nonce.
 	if ( ! wp_verify_nonce( $nonce, "give_form_create_user_nonce_{$form_id}" ) ) {
-		give_set_error( 'invalid_nonce', __( 'Nonce verification has failed.', 'give' ) );
+		give_set_error( 'invalid_nonce', __( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.', 'give' ) );
 	}
 
 	$registering_new_user = false;


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes #4129 to remove the word "nonce" from appearing. This word is considered vulgar in the UK. Additionally, we have formatted these error messages in four different ways. This consolidates them all into one consistent string format to make the job of translating easier for translators. 


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Visual confirmation.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Various strings updated. *NOTE:* `npm run dev` was NOT run, so the `POT` files will be generated later.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.