### PR TITLE
refactor: change the currency symbol and country name of "Swaziland" …

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -293,7 +293,7 @@ function give_get_country_list() {
 		'SD' => esc_html__( 'Sudan', 'give' ),
 		'SR' => esc_html__( 'Suriname', 'give' ),
 		'SJ' => esc_html__( 'Svalbard and Jan Mayen Islands', 'give' ),
-		'SZ' => esc_html__( 'Swaziland', 'give' ),
+		'SZ' => esc_html__( 'Eswatini', 'give' ),
 		'SE' => esc_html__( 'Sweden', 'give' ),
 		'CH' => esc_html__( 'Switzerland', 'give' ),
 		'SY' => esc_html__( 'Syrian Arab Republic', 'give' ),

--- a/includes/currencies-list.php
+++ b/includes/currencies-list.php
@@ -711,8 +711,8 @@ return array(
 		),
 	),
 	'SZL' => array(
-		'admin_label' => sprintf( __( 'Swazi lilangeni (%1$s)', 'give' ), '&#76;' ),
-		'symbol'      => '&#76;',
+		'admin_label' => sprintf( __( 'Swazi lilangeni (%1$s)', 'give' ), '&#69;' ),
+		'symbol'      => '&#69;',
 		'setting'     => array(
 			'currency_position'   => 'before',
 			'thousands_separator' => ',',


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

1. Updated the country name
2. Changed the currency symbol from "L" to "E" 

Resolves #4120 

## Notes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

The name of the currency was not updated from "Swazi lilangeni" because it appears that's what it is still referred to commonly. When I google "Eswatini Emalangeni" the aforementioned name comes up as the currency.

"L" is referred to a singular amount of "1" and "E" with amounts over that, which is most common for donations. Therefore, the symbol has been updated.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.