### PR TITLE
fix: prevent PHP notice when do rest api query #4138

### DIFF
--- a/includes/api/class-give-api.php
+++ b/includes/api/class-give-api.php
@@ -1611,7 +1611,7 @@ class Give_API {
 						);
 
 						// Don't clutter up results with dupes
-						if ( in_array( $meta_key, $exceptions ) ) {
+						if ( ! is_string( $meta_value ) || in_array( $meta_key, $exceptions ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
## Description
This Pr will resolve #4138 

## How Has This Been Tested?
Manually by doing rest API query with a specific donation which has nonempty `_give_payment_meta`.

https://www.loom.com/share/4a23207bdfe146bba94e0e1d187027ba

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.