### PR TITLE
fix: change Swiss Franc symbol to CHF instead of Fr. #4086

### DIFF
--- a/includes/currencies-list.php
+++ b/includes/currencies-list.php
@@ -241,8 +241,8 @@ return array(
 		),
 	),
 	'CHF' => array(
-		'admin_label' => sprintf( __( 'Swiss Franc (%1$s)', 'give' ), '&#70;&#114;' ),
-		'symbol'      => '&#70;&#114;',
+		'admin_label' => sprintf( __( 'Swiss Franc (%1$s)', 'give' ), '&#67;&#72;&#70;' ),
+		'symbol'      => '&#67;&#72;&#70;',
 		'setting'     => array(
 			'currency_position'   => 'before',
 			'thousands_separator' => ' ',


### PR DESCRIPTION
## Description
This PR resolves #4086

## How Has This Been Tested?
I've tested this PR as per the acceptance criteria on the issue description

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/60804229-a95d2480-a19a-11e9-824c-c9dc5d0ececb.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.