### PR TITLE
fix: activating an add-on should display it immediately in activation banner not on refresh #4167

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -169,7 +169,13 @@ class Give_Addon_Activation_Banner {
 				$user_id = __give_get_active_by_user_meta( $banner_addon_name );
 
 				if ( ! $user_id ) {
-					update_option( self::get_banner_user_meta_key( $banner_addon_name ), $this->user_id, false );
+					$option_key = self::get_banner_user_meta_key( $banner_addon_name );
+
+					// store user id who activated add-on.
+					update_option( $option_key, $this->user_id, false );
+
+					// Update global cache.
+					$GLOBALS['give_addon_activated_by_user'][$option_key] = $this->user_id;
 				}
 			}
 		}

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -162,7 +162,7 @@ class Give_Addon_Activation_Banner {
 
 		if ( ! empty( $give_addons ) ) {
 
-			// Go through rach add-ons and add meta data.
+			// Go through each add-ons and add meta data.
 			foreach ( $give_addons as $banner_addon_name => $addon ) {
 
 				// User meta key.


### PR DESCRIPTION
## Description
This Pr will fix #4167 

## How Has This Been Tested?
I perform activation and deactivation on a few add-ons and I was not able to reproduce this issue.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.