### PR TITLE
fix: only show nag when Stripe Premium is lower than 2.2.0

### DIFF
--- a/give.php
+++ b/give.php
@@ -700,10 +700,12 @@ if ( ! class_exists( 'Give' ) ) :
 
 				Give()->notices->register_notice(
 					array(
-						'id'          => 'give-compatibility-with-old-recurring',
-						'type'        => 'error',
-						'description' => $message,
-						'show'        => true,
+						'id'               => 'give-compatibility-with-old-recurring',
+						'type'             => 'error',
+						'description'      => $message,
+						'show'             => true,
+						'dismissible_type' => 'all',
+						'dismiss_interval' => 'shortly',
 					)
 				);
 			}

--- a/give.php
+++ b/give.php
@@ -326,6 +326,9 @@ if ( ! class_exists( 'Give' ) ) :
 				return;
 			}
 
+			// Add compatibility notice for recurring and stripe support with Give 2.5.0.
+			add_action( 'admin_notices', array( $this, 'display_old_recurring_compatibility_notice' ) );
+
 			$this->setup_constants();
 			$this->includes();
 			$this->init_hooks();
@@ -670,6 +673,41 @@ if ( ! class_exists( 'Give' ) ) :
 				'<div class="notice notice-error">%1$s</div>',
 				wp_kses_post( $notice_desc )
 			);
+		}
+
+		/**
+		 * Display compatibility notice for Give 2.5.0 and Recurring 1.8.13 when Stripe premium is not active.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @return void
+		 */
+		public function display_old_recurring_compatibility_notice() {
+
+			// Show notice, if incompatibility found.
+			if (
+				defined( 'GIVE_RECURRING_VERSION' )
+				&& version_compare( GIVE_RECURRING_VERSION, '1.9.0', '<' )
+				&& defined( 'GIVE_STRIPE_VERSION' )
+				&& version_compare( GIVE_STRIPE_VERSION, '2.2.0', '<' )
+			) {
+
+				$message = sprintf(
+					__( '<strong>Attention:</strong> Give 2.5.0+ requires the latest version of the Recurring Donations add-on to process payments properly with Stripe. Please update to the latest version add-on to resolve compatibility issues. If your license is active, you should see the update available in WordPress. Otherwise, you can access the latest version by <a href="%1$s" target="_blank">logging into your account</a> and visiting <a href="%1$s" target="_blank">your downloads</a> page on the GiveWP website.', 'give' ),
+					esc_url( 'https://givewp.com/wp-login.php' ),
+					esc_url( 'https://givewp.com/my-account/#tab_downloads' )
+				);
+
+				Give()->notices->register_notice(
+					array(
+						'id'          => 'give-compatibility-with-old-recurring',
+						'type'        => 'error',
+						'description' => $message,
+						'show'        => true,
+					)
+				);
+			}
+
 		}
 
 		/**

--- a/give.php
+++ b/give.php
@@ -702,7 +702,6 @@ if ( ! class_exists( 'Give' ) ) :
 					array(
 						'id'               => 'give-compatibility-with-old-recurring',
 						'description'      => $message,
-						'show'             => true,
 						'dismissible_type' => 'user',
 						'dismiss_interval' => 'shortly',
 					)

--- a/give.php
+++ b/give.php
@@ -701,10 +701,9 @@ if ( ! class_exists( 'Give' ) ) :
 				Give()->notices->register_notice(
 					array(
 						'id'               => 'give-compatibility-with-old-recurring',
-						'type'             => 'error',
 						'description'      => $message,
 						'show'             => true,
-						'dismissible_type' => 'all',
+						'dismissible_type' => 'user',
 						'dismiss_interval' => 'shortly',
 					)
 				);

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -116,7 +116,8 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 			if (
 				defined( 'GIVE_RECURRING_VERSION' )
 				&& version_compare( GIVE_RECURRING_VERSION, '1.9.0', '<' )
-				&& ! defined( 'GIVE_STRIPE_VERSION' )
+				&& defined( 'GIVE_STRIPE_VERSION' )
+				&& version_compare( GIVE_STRIPE_VERSION, '2.2.0', '<' )
 			) {
 
 				$message = sprintf(

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -29,7 +29,6 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 		 */
 		public function __construct() {
 
-			add_action( 'admin_notices', array( $this, 'display_old_recurring_compatibility_notice' ) );
 			add_filter( 'give_payment_gateways', array( $this, 'register_gateway' ) );
 
 			/**
@@ -101,41 +100,6 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 			);
 
 			return $gateways;
-		}
-
-		/**
-		 * Display compatibility notice for Give 2.5.0 and Recurring 1.8.13 when Stripe premium is not active.
-		 *
-		 * @since 2.5.0
-		 *
-		 * @return void
-		 */
-		public function display_old_recurring_compatibility_notice() {
-
-			// Show notice, if incompatibility found.
-			if (
-				defined( 'GIVE_RECURRING_VERSION' )
-				&& version_compare( GIVE_RECURRING_VERSION, '1.9.0', '<' )
-				&& defined( 'GIVE_STRIPE_VERSION' )
-				&& version_compare( GIVE_STRIPE_VERSION, '2.2.0', '<' )
-			) {
-
-				$message = sprintf(
-					__( '<strong>Attention:</strong> Give 2.5.0+ requires the latest version of the Recurring Donations add-on to process payments properly with Stripe. Please update to the latest version add-on to resolve compatibility issues. If your license is active, you should see the update available in WordPress. Otherwise, you can access the latest version by <a href="%1$s" target="_blank">logging into your account</a> and visiting <a href="%1$s" target="_blank">your downloads</a> page on the GiveWP website.', 'give' ),
-					esc_url( 'https://givewp.com/wp-login.php' ),
-					esc_url( 'https://givewp.com/my-account/#tab_downloads' )
-				);
-
-				Give()->notices->register_notice(
-					array(
-						'id'          => 'give-compatibility-with-old-recurring',
-						'type'        => 'error',
-						'description' => $message,
-						'show'        => true,
-					)
-				);
-			}
-
 		}
 	}
 }


### PR DESCRIPTION
## Description

Only displays the Stripe + Recurring version notice check if Stripe is active and less than version `2.2.0`.

Resolves #4169 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
