### PR TITLE
fix: the stripe connect banner has appearance issues and the temporary disabling of it no longer works #4175

### DIFF
--- a/assets/src/css/admin/stripe-admin.scss
+++ b/assets/src/css/admin/stripe-admin.scss
@@ -10,6 +10,10 @@
     font-size: 15px;
 }
 
+#give-stripe-connect-banner p {
+	font-size: 16px;
+}
+
 #give-stripe-connect {
     display: inline-block;
 

--- a/give.php
+++ b/give.php
@@ -583,7 +583,7 @@ if ( ! class_exists( 'Give' ) ) :
 				! defined( 'GIVE_STRIPE_VERSION' ) ||
 				(
 					defined( 'GIVE_STRIPE_VERSION' ) &&
-					version_compare( '2.2.0', GIVE_STRIPE_VERSION, '>=' )
+					version_compare( GIVE_STRIPE_VERSION, '2.2.0', '>=' )
 				)
 			) {
 				require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/class-give-stripe.php';


### PR DESCRIPTION
## Description
This PR resolves #4175 

## How Has This Been Tested?
I've tested this PR as per the acceptance criteria on the issue. Also, worked on a fatal error which can be caused in future Stripe versions which is fixed within this PR.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.