### PR TITLE
fix: the "empty trash" button needs to be relocated on the "trash" status for donation forms #4075

### DIFF
--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -563,10 +563,13 @@ Donations forms filter
 
 	}
 
-	.bulkactions {
+	.actions{
 		position: absolute;
-		left: 0;
+		left: 230px;
 		bottom: 10px;
-	}
 
+		&.bulkactions {
+			left: 0;
+		}
+	}
 }


### PR DESCRIPTION
## Description
This pr will resolve #4075 

## How Has This Been Tested?
@mehul0810 Button placement looks good but because or CSS button shadow is hidden, i tried to fix but did not find a proper solution. Let know if you can fix it


![image](https://user-images.githubusercontent.com/1784821/61378718-a4e3ea80-a8c3-11e9-8579-2c4277d66ba0.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.