### PR TITLE
fix: exit early from fn if we are on give setting page #4195

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -1095,7 +1095,16 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 		public static function is_setting_page( $tab = '', $section = '' ) {
 			$is_setting_page = false;
 
+			// Are we accessing admin?
 			if( ! is_admin() ) {
+				return $is_setting_page;
+			}
+
+			// Are we accessing any give page?
+			if(
+				! isset( $_GET['post_type'], $_GET['page'] )
+				|| 'give_forms' !== give_clean( $_GET['post_type'] )
+			) {
 				return $is_setting_page;
 			}
 


### PR DESCRIPTION
## Description
This PR will resolve #4195

## How Has This Been Tested?
This code tested with code snippet mentioned in the issue description.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.