### PR TITLE
fix: remove deprecated notice for gutenberg block #4151

### DIFF
--- a/blocks/donation-form-grid/edit/inspector.js
+++ b/blocks/donation-form-grid/edit/inspector.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 const { __ } = wp.i18n;
-const { InspectorControls } = wp.editor;
+const { InspectorControls } = wp.blockEditor;
 const { PanelBody, SelectControl, ToggleControl, TextControl } = wp.components;
 
 /**

--- a/blocks/donation-form/edit/inspector.js
+++ b/blocks/donation-form/edit/inspector.js
@@ -2,7 +2,7 @@
  * Wordpress dependencies
  */
 const { __ } = wp.i18n;
-const { InspectorControls } = wp.editor;
+const { InspectorControls } = wp.blockEditor;
 const { PanelBody, SelectControl, ToggleControl, TextControl } = wp.components;
 const { Component } = wp.element;
 

--- a/blocks/donor-wall/edit/inspector.js
+++ b/blocks/donor-wall/edit/inspector.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 const { __ } = wp.i18n;
-const { InspectorControls } = wp.editor;
+const { InspectorControls } = wp.blockEditor;
 const { PanelBody, SelectControl, ToggleControl, TextControl } = wp.components;
 
 /**


### PR DESCRIPTION
## Description
Replaced deprecated calls to `wp.editor` with `wp.blockEditor`

## How Has This Been Tested?
Installed Give and Gutenberg plugin 6.1.1
Created a donation form
Created a new page and add Give Form block
Checked console for any deprecated notices or errors

## Screenshots (jpeg or gifs if applicable):
N/A

## Types of changes
This fix required changes to the Give Donation Form, Donation Form Grid, and Donor Wall blocks js files only. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.