### PR TITLE
fix: allow title to be set to blank to remove it entirely #4211

### DIFF
--- a/includes/admin/donors/donor-functions.php
+++ b/includes/admin/donors/donor-functions.php
@@ -119,11 +119,11 @@ function give_connect_user_donor_profile( $donor, $donor_data, $address ) {
 			$donor->update_meta( '_give_donor_first_name', $donor_data['first_name'] );
 		}
 
-		if ( ! empty( $donor_data['last_name'] ) ) {
+		if ( isset( $donor_data['last_name'] ) ) {
 			$donor->update_meta( '_give_donor_last_name', $donor_data['last_name'] );
 		}
 
-		if ( ! empty( $donor_data['title'] ) ) {
+		if ( isset( $donor_data['title'] ) ) {
 			$donor->update_meta( '_give_donor_title_prefix', $donor_data['title'] );
 		}
 

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -356,6 +356,7 @@ function give_donor_view( $donor ) {
 						<span class="donor-name info-item edit-item">
 							<select name="donor_info[title]">
 								<option disabled value="0"><?php esc_html_e( 'Title', 'give' ); ?></option>
+								<option value=""><?php esc_html_e( '', 'give' ); ?></option>
 								<?php
 								if ( is_array( $title_prefixes ) && count( $title_prefixes ) > 0 ) {
 									foreach ( $title_prefixes as $title ) {
@@ -1036,7 +1037,7 @@ function give_donor_notes_view( $donor ) {
 }
 
 /**
- * Thw donor delete view.
+ * The donor delete view.
  *
  * @since  1.0
  *


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
New empty option allows admins to remove the title prefix from their name.

![2019-08-01_11-37-01](https://user-images.githubusercontent.com/1571635/62318643-22296680-b451-11e9-9c14-e6a91af1074f.gif)
 
Resolves #4211 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually