### PR TITLE
fix: don't override Stripe email notification settings #4203

### DIFF
--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -336,7 +336,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						'name'    => __( 'Stripe SDK Incompatibility', 'give' ),
 						'desc'    => sprintf(
 							/* translators: 1. GiveWP Support URL */
-							__( 'If you are using another plugin that utilizes Stripe there is a chance that it may include the Stripe SDK (Software development kit) either through composer or manually. This can cause conflicts with GiveWP because WordPress does not have a dependency management system to prevent conflicts. To help resolve conflicts we have included two options to use Stripe alongside these other plugins. The recommended way is Composer, but if that is not working then we recommend Manual Initialization. If both options do not work please <a href="%1$s" target="_blank">contact support</a>.', 'give' ),
+							__( 'If you are using another plugin that uses Stripe to accept payment there is a chance that it may include the Stripe SDK (Software Development Kit) either through composer or manually. This can cause conflicts with GiveWP because WordPress does not have a dependency management system to prevent conflicts. To help resolve conflicts we have included two options to use Stripe alongside these other plugins. The recommended way is Composer, but if that is not working then we recommend Manual Initialization. If both options do not work please <a href="%1$s" target="_blank">contact support</a>.', 'give' ),
 							esc_url_raw( 'https://givewp.com/support' )
 						),
 						'id'      => 'stripe_sdk_incompatibility',
@@ -352,8 +352,8 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						'name' => __( 'Stripe Receipt Emails', 'give' ),
 						'desc' => sprintf(
 							/* translators: 1. GiveWP Support URL */
-							__( 'If you are receiving emails from Stripe in addition to the emails from Give. Then, uncheck this option to stop Stripe emails. If unchecking this option do not work please <a href="%1$s" target="_blank">contact support</a>.', 'give' ),
-							esc_url_raw( 'https://givewp.com/support' )
+							__( 'Check this option if you would like donors to receive receipt emails directly from Stripe. By default, donors will receive GiveWP generated <a href="%1$s" target="_blank">receipt emails</a>.', 'give' ),
+							admin_url( '/edit.php?post_type=give_forms&page=give-settings&tab=emails' )
 						),
 						'id'   => 'stripe_receipt_emails',
 						'type' => 'checkbox',

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -335,6 +335,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 					$settings[] = array(
 						'name'    => __( 'Stripe SDK Incompatibility', 'give' ),
 						'desc'    => sprintf(
+							/* translators: 1. GiveWP Support URL */
 							__( 'If you are using another plugin that utilizes Stripe there is a chance that it may include the Stripe SDK (Software development kit) either through composer or manually. This can cause conflicts with GiveWP because WordPress does not have a dependency management system to prevent conflicts. To help resolve conflicts we have included two options to use Stripe alongside these other plugins. The recommended way is Composer, but if that is not working then we recommend Manual Initialization. If both options do not work please <a href="%1$s" target="_blank">contact support</a>.', 'give' ),
 							esc_url_raw( 'https://givewp.com/support' )
 						),
@@ -345,6 +346,17 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							'manual'   => __( 'Manual Initialization', 'give' ),
 						),
 						'default' => 'composer',
+					);
+
+					$settings[] = array(
+						'name' => __( 'Stripe Receipt Emails', 'give' ),
+						'desc' => sprintf(
+							/* translators: 1. GiveWP Support URL */
+							__( 'If you are receiving emails from Stripe in addition to the emails from Give. Then, uncheck this option to stop Stripe emails. If unchecking this option do not work please <a href="%1$s" target="_blank">contact support</a>.', 'give' ),
+							esc_url_raw( 'https://givewp.com/support' )
+						),
+						'id'   => 'stripe_receipt_emails',
+						'type' => 'checkbox',
 					);
 
 					$settings[] = array(

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1069,7 +1069,6 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 						'currency'             => give_get_currency( $form_id ),
 						'payment_method_types' => [ 'card' ],
 						'statement_descriptor' => give_stripe_get_statement_descriptor(),
-						'receipt_email'        => $donation_data['user_email'],
 						'description'          => give_payment_gateway_donation_summary( $donation_data ),
 						'metadata'             => $stripe_gateway->prepare_metadata( $donation_id ),
 						'customer'             => $stripe_customer_id,
@@ -1078,7 +1077,13 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 						'return_url'           => give_get_success_page_uri(),
 					)
 				);
-				$intent     = $stripe_gateway->payment_intent->create( $intent_args );
+
+				// Send Stripe Receipt emails when enabled.
+				if ( give_is_setting_enabled( give_get_option( 'stripe_receipt_emails' ) ) ) {
+					$intent_args['receipt_email'] = $donation_data['user_email'];
+				}
+
+				$intent = $stripe_gateway->payment_intent->create( $intent_args );
 
 				// Save Payment Intent Client Secret to donation note and DB.
 				give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
@@ -232,7 +232,6 @@ if ( ! class_exists( 'Give_Stripe_Card' ) ) {
 								'currency'             => give_get_currency( $form_id ),
 								'payment_method_types' => [ 'card' ],
 								'statement_descriptor' => give_stripe_get_statement_descriptor(),
-								'receipt_email'        => $donation_data['user_email'],
 								'description'          => give_payment_gateway_donation_summary( $donation_data ),
 								'metadata'             => $this->prepare_metadata( $donation_id ),
 								'customer'             => $stripe_customer_id,
@@ -241,7 +240,13 @@ if ( ! class_exists( 'Give_Stripe_Card' ) ) {
 								'return_url'           => give_get_success_page_uri(),
 							)
 						);
-						$intent     = $this->payment_intent->create( $intent_args );
+
+						// Send Stripe Receipt emails when enabled.
+						if ( give_is_setting_enabled( give_get_option( 'stripe_receipt_emails' ) ) ) {
+							$intent_args['receipt_email'] = $donation_data['user_email'];
+						}
+
+						$intent = $this->payment_intent->create( $intent_args );
 
 						// Save Payment Intent Client Secret to donation note and DB.
 						give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );


### PR DESCRIPTION
## Description
This PR resolves #4203 

## How Has This Been Tested?
I've tested this PR on local as well LIVE demo site on Pantheon but unable to receive any email from Stripe end. However, as per the description I'm sure that the email from Stripe is no longer sent out with default admin settings as per the screenshot below.

**Note:** There is no Stripe email sent out from Stripe Premium add-on as of now so no need to do any changes there.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/62370739-93037800-b550-11e9-9ca0-6e82ab3cf048.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.