### PR TITLE
fix: add constant for TCPDF to function properly with ticketa

### DIFF
--- a/give.php
+++ b/give.php
@@ -552,8 +552,6 @@ if ( ! class_exists( 'Give' ) ) :
 			require_once GIVE_PLUGIN_DIR . 'includes/class-give-donor-wall-widget.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/forms/widget.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/forms/class-give-forms-query.php';
-
-
 			require_once GIVE_PLUGIN_DIR . 'includes/forms/template.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/shortcodes.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/formatting.php';

--- a/includes/plugin-compatibility.php
+++ b/includes/plugin-compatibility.php
@@ -13,10 +13,30 @@
 
 
 /**
+ * If Tickera is active then allow TCPDF calls in HTML.
+ *
+ * TCPDF defines this as false by default as a security precaution. Because Tickera uses GiveWP's composer autoloaded
+ * TCPDF the constant is false. Therefore, we will set it to true so the QR code feature works as expected.
+ *
+ * GitHub Issue:
+ * See: https://tcpdf.org/examples/example_049/
+ *
+ * @since 2.5.4
+ *
+ */
+function give_tickera_qr_compatibility() {
+	if ( is_plugin_active( 'tickera-event-ticketing-system/tickera.php' ) ) {
+		define( 'K_TCPDF_CALLS_IN_HTML', true );
+	}
+}
+
+add_action( 'plugins_loaded', 'give_tickera_qr_compatibility' );
+
+/**
  * Disables the mandrill_nl2br filter while sending Give emails.
  *
- * @since 1.4
  * @return void
+ * @since 1.4
  */
 function give_disable_mandrill_nl2br() {
 	add_filter( 'mandrill_nl2br', '__return_false' );
@@ -28,9 +48,9 @@ add_action( 'give_email_send_before', 'give_disable_mandrill_nl2br' );
 /**
  * This function will clear the Yoast SEO sitemap cache on update of settings
  *
+ * @return void
  * @since 1.8.9
  *
- * @return void
  */
 function give_clear_seo_sitemap_cache_on_settings_change() {
 	// Load required file if the fn 'is_plugin_active' doesn't exists.
@@ -69,9 +89,9 @@ add_action( 'give-settings_save_display', 'give_clear_seo_sitemap_cache_on_setti
  *
  * See link: https://github.com/impress-org/give/issues/3171#issuecomment-387471355
  *
+ * @return boolean
  * @since 2.1.3
  *
- * @return boolean
  */
 function give_elementor_hide_shortcodes_button() {
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

TCPDF defines `K_TCPDF_CALLS_IN_HTML` as false by default as a security precaution. Because Tickera uses GiveWP's composer autoloaded TCPDF version (same version they use) the constant is set to false. Therefore, we will set it to true so the QR code feature works as expected.

Resolves #3880 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- manually

## Screenshots (jpeg or gifs if applicable):

![2019-08-05_18-46-50](https://user-images.githubusercontent.com/1571635/62505402-69955700-b7b1-11e9-8458-5907810ac107.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- plugin compatibility

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.