### PR TITLE
fix: prevent "this plugin does not have a valid header" #4217

### DIFF
--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -25,18 +25,16 @@ function give_upload_addon_handler() {
 	/* @var WP_Filesystem_Direct $wp_filesystem */
 	global $wp_filesystem;
 
-	$filename      = basename( $_FILES['file']['name'], '.zip' );
-
 	check_admin_referer( 'give-upload-addon' );
+
+	// Remove version from file name.
+	$filename = preg_replace(  '/(.\d)+.zip/', '', $_FILES['file']['name']  );
+	$filename = basename( $filename, '.zip' );
+
 
 	// Bailout if user does not has permission.
 	if ( ! current_user_can( 'upload_plugins' ) ) {
 		wp_send_json_error( array( 'errorMsg' => __( 'Sorry, you are not allowed to upload add-ons on this site.', 'give' ) ) );
-	}
-
-	// Bailout if not upload file or not uploading Give addon
-	if ( empty( $_FILES ) || false === stripos( $filename, 'Give' ) ) {
-		wp_send_json_error( array( 'errorMsg' => __( 'Please upload a valid add-on file.', 'give' ) ) );
 	}
 
 	$access_type = get_filesystem_method();
@@ -58,7 +56,7 @@ function give_upload_addon_handler() {
 		wp_send_json_error( array( 'errorMsg' =>  __( 'Only zip file type allowed to upload. Please upload a valid add-on file.', 'give' ) ) );
 	}
 
-	$give_addons_list   = give_get_plugins( array( 'only_premium_add_ons' => true ) );
+	$give_addons_list   = give_get_plugins();
 	$is_addon_installed = array();
 
 	if ( ! empty( $give_addons_list ) ) {
@@ -111,7 +109,7 @@ function give_upload_addon_handler() {
 
 	// Delete cache and get current installed addon plugin path.
 	wp_cache_delete( 'plugins', 'plugins' );
-	$give_addons_list   = give_get_plugins( array( 'only_premium_add_ons' => true ) );
+	$give_addons_list   = give_get_plugins();
 	$installed_addon  = array();
 
 	if ( ! empty( $give_addons_list ) ) {

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -25,7 +25,6 @@ function give_upload_addon_handler() {
 	/* @var WP_Filesystem_Direct $wp_filesystem */
 	global $wp_filesystem;
 
-	$addon_authors = array( 'WordImpress', 'GiveWP' );
 	$filename      = basename( $_FILES['file']['name'], '.zip' );
 
 	check_admin_referer( 'give-upload-addon' );
@@ -59,16 +58,11 @@ function give_upload_addon_handler() {
 		wp_send_json_error( array( 'errorMsg' =>  __( 'Only zip file type allowed to upload. Please upload a valid add-on file.', 'give' ) ) );
 	}
 
-	$give_addons_list   = give_get_plugins();
+	$give_addons_list   = give_get_plugins( array( 'only_premium_add_ons' => true ) );
 	$is_addon_installed = array();
 
 	if ( ! empty( $give_addons_list ) ) {
 		foreach ( $give_addons_list as $addon => $give_addon ) {
-			// Only show Give Core Activated Add-Ons.
-			if ( ! in_array( $give_addon['AuthorName'], $addon_authors ) ) {
-				continue;
-			}
-
 			if ( false !== stripos( $addon, $filename ) ) {
 				$is_addon_installed = $give_addon;
 			}
@@ -117,16 +111,11 @@ function give_upload_addon_handler() {
 
 	// Delete cache and get current installed addon plugin path.
 	wp_cache_delete( 'plugins', 'plugins' );
-	$give_addons_list = get_plugins();
+	$give_addons_list   = give_get_plugins( array( 'only_premium_add_ons' => true ) );
 	$installed_addon  = array();
 
 	if ( ! empty( $give_addons_list ) ) {
 		foreach ( $give_addons_list as $addon => $give_addon ) {
-			// Only show Give Core Activated Add-Ons.
-			if ( ! in_array( $give_addon['AuthorName'], $addon_authors ) ) {
-				continue;
-			}
-
 			if ( false !== stripos( $addon, $filename ) ) {
 				$installed_addon         = $give_addon;
 				$installed_addon['path'] = $addon;


### PR DESCRIPTION
## Description
This will resolve #4217 

## How Has This Been Tested?
I uploaded and activate add-ons mentioned in `Acceptance Criteria` from Give plugin uploader.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.